### PR TITLE
Add CLAUDE.md project handoff + domain/ad updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,19 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 # If left as placeholder, app falls back to free CARTO tiles
 NEXT_PUBLIC_MAPTILER_KEY=YOUR_MAPTILER_KEY
 
+# ── Tracker ingestion (flespi) ──────────────────────────────────────────────
+# Token your flespi stream sends in the x-flespi-token header.
+# Leave unset in demo mode (the endpoint accepts and reports mode:demo).
+FLESPI_WEBHOOK_TOKEN=
+
+# ── QuickBooks Online integration ───────────────────────────────────────────
+# Create an app at https://developer.intuit.com (scope: com.intuit.quickbooks.accounting)
+# Leave QBO_CLIENT_ID unset to run QuickBooks in demo mode.
+QBO_CLIENT_ID=
+QBO_CLIENT_SECRET=
+QBO_REDIRECT_URI=http://localhost:3000/api/qbo/callback
+QBO_ENVIRONMENT=sandbox
+
 # ──────────────────────────────────────────────────────────────────────────────
 # DEMO MODE: If NEXT_PUBLIC_SUPABASE_URL is the placeholder above, the app
 # runs in demo mode with mock data (Nashville, TN construction site).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# HammerTrack — Project Handoff
+
+## What This Is
+Mobile-first asset tracking SaaS for construction companies. Competes with Tenna at lower price.
+Tracks vehicles (OBD2), heavy equipment (GPS), personnel, small tools (Bluetooth) on a live map.
+Owner: Brian Dillard / Dillard Construction Group (Nashville, TN area).
+
+## Live Site
+- **URL:** https://hammertrackai.com
+- **Host:** Netlify (project: stately-heliotrope-0b2bff)
+- **Repo:** github.com/briandillardre/hello-world
+- **Branch:** master (main working branch — all v2 features merged)
+- **Dev branch convention:** `claude/...` branches, open PR → squash merge to master
+
+## Tech Stack
+- Next.js 14 (App Router, TypeScript)
+- Supabase — Postgres + PostGIS, Auth, Realtime (demo mode when env vars absent)
+- MapLibre GL JS — open-source map, CARTO free tiles
+- Tailwind CSS + shadcn/ui
+- Netlify deployment (netlify.toml + @netlify/plugin-nextjs)
+
+## Demo Mode
+App works fully with zero env vars — 10 mock assets at a Nashville construction site.
+`isMock` flag checks `NEXT_PUBLIC_SUPABASE_URL === 'https://your-project.supabase.co'`.
+
+## Key Files
+- `lib/types.ts` — all TypeScript types
+- `lib/mock-data.ts` — demo data (Dillard Construction Group)
+- `lib/flespi.ts` — normalizes Teltonika + Digital Matter telemetry
+- `lib/alerts-engine.ts` — pure alert evaluation (after-hours theft, left-site, etc.)
+- `lib/qbo.ts` — QuickBooks Online OAuth2 + invoice generation
+- `lib/db/tools.ts` — BLE tool association / location inheritance
+- `lib/db/maintenance.ts` — service schedules + overdue tracking
+- `app/api/ingest/flespi/route.ts` — flespi webhook (Teltonika/Digital Matter)
+- `app/api/ingest/obd2/route.ts` — direct OBD2 ingestion
+- `app/api/ingest/location/route.ts` — direct GPS ingestion
+- `app/(dashboard)/map/page.tsx` — live map with tool gateway resolution
+- `app/demo/page.tsx` — public marketing landing page (theft-hook funnel)
+- `app/pricing/page.tsx` — public pricing page (Tenna comparison)
+- `marketing/lead-funnel-infographic.html` — GTM funnel infographic
+- `marketing/ad-variants.md` — Google Search, dealer, cold email ad copy
+- `supabase/migrations/001_initial.sql` — full schema with PostGIS + RLS
+- `supabase/migrations/002_v2.sql` — tool_associations, maintenance, QBO tables
+
+## Features Built
+- Live map with clustering (MapLibre GL JS)
+- BLE tool tracking — tools inherit location of truck/equipment that detects them
+- Geofences (draw on map) + alerts engine
+- After-hours theft alerts + left-site alerts (red "THEFT ALERT" styling)
+- Maintenance schedules (engine hours / mileage / days) + service history
+- Utilization reports (engine hours, idle %, miles, hours per job site)
+- QuickBooks Online integration (OAuth2, asset sync, job-cost invoices, expenses)
+- flespi connector — Teltonika FMM series + Digital Matter normalized to same schema
+- Pricing page with Tenna comparison
+- Demo landing page at /demo (ad funnel landing page)
+- PWA (manifest.json)
+- Mobile bottom nav with "More" drawer
+
+## Hardware Stack (Decided)
+| Role | Device | Notes |
+|------|--------|-------|
+| Trucks | Teltonika FMM003 | OBD2 plug-in, Cat-M1, BLE 4.0 gateway |
+| Equipment | Teltonika TAT141 | Cat-M1, BLE 5.2, IP68, Li-SOCl2 battery |
+| Tool tags | BlueCharm BC021 | BLE iBeacon, IP67, $20, Amazon Prime |
+| SIM cards | Hologram (hologram.io) | nano SIM, Cat-M1, ~$1-2/mo per device |
+
+### TAT141 Battery Note
+At active tracking rates (5-min intervals when moving), battery alone is insufficient.
+**Need solar accessory** for equipment left outside, or wire to 12V/24V aux on machines that have it.
+Ask Teltonika Americas for TAT141 solar charging accessory.
+
+### CAN Bus — Phase 2
+Start with GPS/battery. Add J1939 CAN readers on high-value machines later for:
+true engine hours, fuel consumption, fault codes, accurate utilization billing.
+
+## Domain & DNS
+- **Primary domain:** hammertrackai.com (Namecheap)
+- **Also owned:** hammertracks.com, hammertrax.com (redirect to primary)
+- **Deferred:** hammertrack.ai ($185.96 for 2yr min — buy when business is proven)
+- DNS: A record @ → 75.2.60.5, CNAME www → stately-heliotrope-0b2bff.netlify.app
+- SSL: Let's Encrypt via Netlify, auto-renews Aug 27
+
+## Env Vars Needed for Production
+```
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+NEXT_PUBLIC_MAPTILER_KEY=       # optional, falls back to CARTO free tiles
+FLESPI_WEBHOOK_TOKEN=           # from flespi stream config
+QBO_CLIENT_ID=                  # from developer.intuit.com
+QBO_CLIENT_SECRET=
+QBO_REDIRECT_URI=https://hammertrackai.com/api/qbo/callback
+QBO_ENVIRONMENT=production
+```
+
+## Pending / Next Steps
+1. **Hardware order** — FMM003 (trucks), TAT141 + solar accessory (equipment), BC021 (tools), Hologram SIMs
+2. **flespi account** — flespi.com, add device IMEIs, create webhook stream → hammertrackai.com/api/ingest/flespi
+3. **Supabase production** — create project, run 001_initial.sql then 002_v2.sql
+4. **Add Netlify env vars** — paste Supabase keys into Netlify dashboard
+5. **QuickBooks** — create app at developer.intuit.com, add QBO_ env vars
+6. **Solar question** — confirm TAT141 solar accessory availability with Teltonika Americas
+7. **hammertrack.ai domain** — buy when business proves out ($185.96/2yr at Namecheap)
+
+## Go-to-Market
+- Lead funnel: FB/IG theft-hook ad → hammertrackai.com/demo → /register
+- Primary hook: after-hours theft alert ("Your excavator left at 2 AM")
+- Price position: $3-8/asset/mo vs Tenna $15-25/asset/mo + $500 setup
+- Beachhead: Nashville metro, local contractor Facebook groups + equipment dealer referrals
+- Ad variants ready in marketing/ad-variants.md
+
+## Competitors
+- Tenna: $15-25/asset + $500 setup, enterprise, no Bluetooth tools, no QuickBooks
+- Samsara: $20-40, built for trucking, overkill for GCs
+- Verizon Connect: $20-35, sticky contracts, dated UX
+- GPS Trackit: $15-25, vehicle-centric, weak on tools/equipment
+
+## Notes
+- All HMAC secrets use `hammertrack-*` prefix (previously trackflow-*)
+- flespi normalizer handles both Teltonika Codec 8/8E and Digital Matter field conventions
+- Tool tracking: tools have no GPS, inherit gateway (truck/equipment) location via tool_associations table
+- Timing-safe API auth on all ingest endpoints (createHmac + timingSafeEqual)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Track vehicles (OBD2), heavy equipment (GPS), personnel, and small tools (Blueto
 - **MapLibre GL JS** — open-source map renderer (no per-tile license fees)
 - **Tailwind CSS + shadcn/ui** — mobile-first components
 
+## Features
+
+- **Live map** — vehicles, equipment, personnel, Bluetooth tools with clustering
+- **Bluetooth tool tracking** — tools are located by the truck/equipment that detects them ("Drill Kit is in Truck #1")
+- **Geofences & alerts** — including **after-hours movement (theft)** and **left-site** alerts
+- **Maintenance** — service schedules (engine hours / mileage / days) with overdue tracking + service history
+- **Utilization reports** — engine hours, idle %, miles, and hours-per-job-site
+- **QuickBooks Online** — sync assets, allocate equipment cost to job sites, auto-bill usage, record service expenses
+- **Real device ingestion** — Teltonika & Digital Matter via flespi; plus direct OBD2/location APIs
+- **Pricing page** — public `/pricing`
+
 ## Quick Start
 
 ```bash
@@ -54,7 +65,36 @@ x-api-key: YOUR_API_KEY
 
 ### Bluetooth Tools
 
-BLE tags pair with a companion mobile app that scans nearby BLE beacons and POSTs their location to `/api/ingest/location`.
+Register each tool asset with its **BLE beacon ID/MAC as the `tracker_id`**. When a truck/equipment gateway (Teltonika/Digital Matter) detects the beacon, the tool is automatically associated with that gateway and inherits its location on the map.
+
+## Connecting Cat-M1 trackers via flespi (recommended for production)
+
+Professional Cat-M1 trackers — **Teltonika FMM130** (vehicles, OBD2 + BLE gateway) and **Digital Matter Oyster3** (equipment, 10-yr battery + BLE gateway) — stream through [flespi](https://flespi.com), which parses their protocol and forwards normalized JSON to TrackFlow.
+
+1. Add your devices in flespi (by IMEI) — flespi auto-detects Teltonika/Digital Matter.
+2. Set each device's flespi `ident` (IMEI) to match the asset's `tracker_id` in TrackFlow.
+3. Create a flespi **stream** of type *webhook* pointing at:
+   ```
+   POST https://<your-app>/api/ingest/flespi
+   Header: x-flespi-token: <FLESPI_WEBHOOK_TOKEN>
+   ```
+4. The endpoint accepts a single message or an array, parses GPS/battery/speed, and registers any detected BLE beacons as tool→gateway associations.
+
+In demo mode (no `FLESPI_WEBHOOK_TOKEN`), the endpoint accepts requests and returns `mode: "demo"` without persisting.
+
+## QuickBooks Online integration
+
+1. Create an app at [developer.intuit.com](https://developer.intuit.com) with scope `com.intuit.quickbooks.accounting`.
+2. Set the redirect URI to `https://<your-app>/api/qbo/callback`.
+3. Add `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`, `QBO_REDIRECT_URI`, and `QBO_ENVIRONMENT` to `.env.local`.
+4. Visit **Settings → Connect QuickBooks**, or the **Accounting** page.
+
+What it does:
+- **Assets → QuickBooks** fixed-asset items
+- **Job sites (geofences) → Customers/Projects**, with equipment-usage invoices built from utilization × hourly rates
+- **Service records → expenses**
+
+Without `QBO_CLIENT_ID`, QuickBooks runs in **demo mode** (mock connection + invoice previews, nothing sent to Intuit).
 
 ## PWA Install
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TrackFlow
+# HammerTrack
 
 Mobile-first asset tracking SaaS for construction companies. Competes with Tenna at a lower price point.
 
@@ -69,10 +69,10 @@ Register each tool asset with its **BLE beacon ID/MAC as the `tracker_id`**. Whe
 
 ## Connecting Cat-M1 trackers via flespi (recommended for production)
 
-Professional Cat-M1 trackers — **Teltonika FMM130** (vehicles, OBD2 + BLE gateway) and **Digital Matter Oyster3** (equipment, 10-yr battery + BLE gateway) — stream through [flespi](https://flespi.com), which parses their protocol and forwards normalized JSON to TrackFlow.
+Professional Cat-M1 trackers — **Teltonika FMM130** (vehicles, OBD2 + BLE gateway) and **Digital Matter Oyster3** (equipment, 10-yr battery + BLE gateway) — stream through [flespi](https://flespi.com), which parses their protocol and forwards normalized JSON to HammerTrack.
 
 1. Add your devices in flespi (by IMEI) — flespi auto-detects Teltonika/Digital Matter.
-2. Set each device's flespi `ident` (IMEI) to match the asset's `tracker_id` in TrackFlow.
+2. Set each device's flespi `ident` (IMEI) to match the asset's `tracker_id` in HammerTrack.
 3. Create a flespi **stream** of type *webhook* pointing at:
    ```
    POST https://<your-app>/api/ingest/flespi
@@ -109,7 +109,7 @@ npm run build && npm start   # self-hosted
 
 ## Pricing vs Tenna
 
-| Feature | TrackFlow | Tenna |
+| Feature | HammerTrack | Tenna |
 |---|---|---|
 | Live map | ✅ | ✅ |
 | Geofencing & alerts | ✅ | ✅ |

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -102,6 +102,12 @@ export default function LoginPage() {
             View demo →
           </Link>
         </p>
+
+        <p className="text-center text-xs text-slate-500">
+          <Link href="/pricing" className="text-slate-400 hover:text-amber-400 hover:underline">
+            See pricing & how we compare to Tenna →
+          </Link>
+        </p>
       </div>
     </div>
   )

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -47,7 +47,7 @@ export default function LoginPage() {
           <div className="w-14 h-14 bg-amber-500 rounded-2xl flex items-center justify-center mx-auto mb-4">
             <Map className="h-7 w-7 text-white" />
           </div>
-          <h1 className="text-2xl font-bold text-white">TrackFlow</h1>
+          <h1 className="text-2xl font-bold text-white">HammerTrack</h1>
           <p className="text-slate-400 text-sm mt-1">Asset tracking for construction</p>
         </div>
 

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -66,7 +66,7 @@ export default function RegisterPage() {
           <div className="w-14 h-14 bg-amber-500 rounded-2xl flex items-center justify-center mx-auto mb-4">
             <Map className="h-7 w-7 text-white" />
           </div>
-          <h1 className="text-2xl font-bold text-white">TrackFlow</h1>
+          <h1 className="text-2xl font-bold text-white">HammerTrack</h1>
           <p className="text-slate-400 text-sm mt-1">Asset tracking for construction</p>
         </div>
 

--- a/app/(dashboard)/accounting/page.tsx
+++ b/app/(dashboard)/accounting/page.tsx
@@ -1,0 +1,38 @@
+import { AccountingView } from '@/components/accounting/AccountingView'
+import { getConnectionStatus, buildEquipmentUsageInvoice } from '@/lib/qbo'
+import { getAssets } from '@/lib/db/assets'
+import { getGeofences } from '@/lib/db/geofences'
+import { MOCK_COMPANY } from '@/lib/mock-data'
+import type { QboInvoicePreview } from '@/lib/types'
+
+export default async function AccountingPage() {
+  const status = getConnectionStatus()
+  const [assets, geofences] = await Promise.all([
+    getAssets(MOCK_COMPANY.id),
+    getGeofences(MOCK_COMPANY.id),
+  ])
+
+  const invoicesByFence: Record<string, QboInvoicePreview> = {}
+  for (const g of geofences) {
+    invoicesByFence[g.id] = buildEquipmentUsageInvoice(g.id, g.name)
+  }
+
+  // status.connection is non-null in demo mode; guard for the unconfigured path.
+  if (!status.connection) {
+    return (
+      <div className="h-full flex items-center justify-center p-8 text-center text-slate-400">
+        QuickBooks not connected.
+      </div>
+    )
+  }
+
+  return (
+    <AccountingView
+      connection={status.connection}
+      demo={status.demo}
+      assets={assets}
+      geofences={geofences}
+      invoicesByFence={invoicesByFence}
+    />
+  )
+}

--- a/app/(dashboard)/maintenance/page.tsx
+++ b/app/(dashboard)/maintenance/page.tsx
@@ -1,0 +1,107 @@
+import { Wrench, AlertTriangle, CheckCircle2, Clock } from 'lucide-react'
+import { getMaintenanceSchedules, getServiceRecords, getCurrentReadings, computeStatus } from '@/lib/db/maintenance'
+import { getAssets } from '@/lib/db/assets'
+import { MOCK_COMPANY } from '@/lib/mock-data'
+import { Badge } from '@/components/ui/badge'
+import { formatRelativeTime } from '@/lib/utils'
+
+const STATUS_META = {
+  overdue: { label: 'Overdue', variant: 'destructive' as const, icon: AlertTriangle, bar: 'bg-red-500' },
+  due_soon: { label: 'Due soon', variant: 'default' as const, icon: Clock, bar: 'bg-amber-500' },
+  ok: { label: 'OK', variant: 'success' as const, icon: CheckCircle2, bar: 'bg-green-500' },
+}
+
+const UNIT = { engine_hours: 'hrs', mileage: 'mi', days: 'days' }
+
+export default async function MaintenancePage() {
+  const [schedules, assets, readings, services] = await Promise.all([
+    getMaintenanceSchedules(MOCK_COMPANY.id),
+    getAssets(MOCK_COMPANY.id),
+    getCurrentReadings(),
+    getServiceRecords(MOCK_COMPANY.id),
+  ])
+
+  const assetName = (id: string) => assets.find(a => a.id === id)?.name ?? 'Unknown asset'
+
+  const statuses = schedules
+    .map(s => ({ ...computeStatus(s, readings[s.asset_id] ?? s.last_service_value), name: assetName(s.asset_id) }))
+    .sort((a, b) => a.remaining - b.remaining)
+
+  const overdueCount = statuses.filter(s => s.status === 'overdue').length
+  const totalSpent = services.reduce((sum, r) => sum + r.cost, 0)
+
+  return (
+    <div className="h-full overflow-auto pb-[70px] md:pb-0">
+      <div className="p-4 border-b border-slate-100 bg-white sticky top-0 z-10 flex items-center gap-3">
+        <h1 className="text-xl font-bold text-slate-900">Maintenance</h1>
+        {overdueCount > 0 && <Badge variant="destructive">{overdueCount} overdue</Badge>}
+        <span className="ml-auto text-sm text-slate-400">
+          ${totalSpent.toLocaleString(undefined, { minimumFractionDigits: 2 })} YTD
+        </span>
+      </div>
+
+      <div className="p-4 space-y-6 max-w-2xl">
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">Service Schedule</h2>
+          {statuses.map(s => {
+            const meta = STATUS_META[s.status]
+            const Icon = meta.icon
+            return (
+              <div key={s.id} className="bg-white rounded-xl border border-slate-200 p-4 shadow-sm">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center flex-shrink-0">
+                    <Wrench className="h-5 w-5 text-slate-500" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-slate-900 truncate">{s.name}</p>
+                    <p className="text-xs text-slate-500">{s.description}</p>
+                  </div>
+                  <Badge variant={meta.variant} className="flex items-center gap-1">
+                    <Icon className="h-3 w-3" />
+                    {meta.label}
+                  </Badge>
+                </div>
+                <div className="mt-3">
+                  <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+                    <div className={`h-full ${meta.bar} rounded-full transition-all`} style={{ width: `${Math.min(100, s.pct)}%` }} />
+                  </div>
+                  <div className="flex justify-between mt-1 text-xs text-slate-400">
+                    <span>{Math.round(s.used)} / {s.interval_value} {UNIT[s.interval_type]}</span>
+                    <span>
+                      {s.remaining <= 0
+                        ? `${Math.abs(Math.round(s.remaining))} ${UNIT[s.interval_type]} overdue`
+                        : `${Math.round(s.remaining)} ${UNIT[s.interval_type]} remaining`}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">Service History</h2>
+          <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 shadow-sm">
+            {services.map(r => (
+              <div key={r.id} className="p-4 flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-slate-900 text-sm truncate">{assetName(r.asset_id)}</p>
+                  <p className="text-xs text-slate-500 truncate">{r.notes}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">
+                    {r.vendor} · {formatRelativeTime(r.service_date)}
+                  </p>
+                </div>
+                <span className="font-semibold text-slate-700 text-sm flex-shrink-0">
+                  ${r.cost.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-slate-400 text-center">
+            Service costs sync to QuickBooks as expenses → see Accounting.
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/map/page.tsx
+++ b/app/(dashboard)/map/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
-import { MOCK_ASSETS, MOCK_GEOFENCES } from '@/lib/mock-data'
+import { MOCK_ASSETS, MOCK_GEOFENCES, MOCK_TOOL_ASSOCIATIONS } from '@/lib/mock-data'
+import { resolveToolLocations } from '@/lib/db/tools'
 
 const MapView = dynamic(
   () => import('@/components/map/MapView').then(m => ({ default: m.MapView })),
@@ -17,12 +18,20 @@ const MapView = dynamic(
 )
 
 export default function MapPage() {
+  // Tools have no GPS of their own — resolve their position from the gateway
+  // (truck/equipment) that currently detects them over Bluetooth.
+  const assets = resolveToolLocations(MOCK_ASSETS, MOCK_TOOL_ASSOCIATIONS)
+
+  // Map each tool to the gateway holding it, for the asset detail panel.
+  const toolGateways: Record<string, { name: string; lastSeen: string }> = {}
+  for (const assoc of MOCK_TOOL_ASSOCIATIONS) {
+    const gateway = MOCK_ASSETS.find(a => a.id === assoc.gateway_asset_id)
+    if (gateway) toolGateways[assoc.tool_asset_id] = { name: gateway.name, lastSeen: assoc.last_seen }
+  }
+
   return (
     <div className="h-full pb-[70px] md:pb-0">
-      <MapView
-        assets={MOCK_ASSETS}
-        geofences={MOCK_GEOFENCES}
-      />
+      <MapView assets={assets} geofences={MOCK_GEOFENCES} toolGateways={toolGateways} />
     </div>
   )
 }

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react'
+import { Activity, Clock, Gauge, MapPin } from 'lucide-react'
+import { MOCK_UTILIZATION } from '@/lib/mock-data'
+import type { AssetType } from '@/lib/types'
+
+const TYPE_EMOJI: Record<AssetType, string> = {
+  vehicle: '🚛', equipment: '🏗️', personnel: '👷', tool: '🔧',
+}
+
+export default function ReportsPage() {
+  const util = MOCK_UTILIZATION
+  const totalEngineHours = util.reduce((s, u) => s + u.engine_hours, 0)
+  const totalIdle = util.reduce((s, u) => s + u.idle_hours, 0)
+  const totalDistance = util.reduce((s, u) => s + u.distance_miles, 0)
+  const maxEngine = Math.max(...util.map(u => u.engine_hours), 1)
+  const idlePct = totalEngineHours > 0 ? Math.round((totalIdle / (totalEngineHours + totalIdle)) * 100) : 0
+
+  return (
+    <div className="h-full overflow-auto pb-[70px] md:pb-0">
+      <div className="p-4 border-b border-slate-100 bg-white sticky top-0 z-10">
+        <h1 className="text-xl font-bold text-slate-900">Utilization Reports</h1>
+        <p className="text-xs text-slate-400 mt-0.5">Last 30 days</p>
+      </div>
+
+      <div className="p-4 space-y-6 max-w-2xl">
+        <section className="grid grid-cols-3 gap-3">
+          <SummaryCard icon={<Activity className="h-4 w-4 text-amber-500" />} label="Engine hours" value={`${totalEngineHours}`} />
+          <SummaryCard icon={<Clock className="h-4 w-4 text-red-500" />} label="Idle %" value={`${idlePct}%`} />
+          <SummaryCard icon={<Gauge className="h-4 w-4 text-blue-500" />} label="Miles" value={totalDistance.toLocaleString()} />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">Engine Hours by Asset</h2>
+          <div className="bg-white rounded-xl border border-slate-200 p-4 space-y-3 shadow-sm">
+            {util.map(u => (
+              <div key={u.asset_id}>
+                <div className="flex justify-between text-sm mb-1">
+                  <span className="text-slate-700 font-medium">{TYPE_EMOJI[u.asset_type]} {u.asset_name}</span>
+                  <span className="text-slate-500">{u.engine_hours} hrs</span>
+                </div>
+                <div className="h-2.5 bg-slate-100 rounded-full overflow-hidden">
+                  <div className="h-full bg-amber-500 rounded-full" style={{ width: `${(u.engine_hours / maxEngine) * 100}%` }} />
+                </div>
+                <p className="text-xs text-slate-400 mt-0.5">{u.idle_hours} hrs idle</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">Hours by Job Site</h2>
+          <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 shadow-sm">
+            {util.map(u => (
+              <div key={u.asset_id} className="p-4">
+                <p className="font-medium text-slate-900 text-sm mb-1">{u.asset_name}</p>
+                {u.job_site_hours.map(s => (
+                  <div key={s.geofence_id} className="flex items-center gap-2 text-xs text-slate-500 mt-1">
+                    <MapPin className="h-3 w-3 text-slate-400" />
+                    <span className="flex-1">{s.geofence_name}</span>
+                    <span className="font-medium text-slate-700">{s.hours} hrs</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-slate-400 text-center">
+            Job-site hours drive equipment-usage billing → see Accounting.
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function SummaryCard({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-3 shadow-sm">
+      <div className="flex items-center gap-1.5 mb-1">{icon}</div>
+      <p className="text-xl font-bold text-slate-900">{value}</p>
+      <p className="text-xs text-slate-400">{label}</p>
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
-import { Key, Map, Package, Wifi } from 'lucide-react'
+import Link from 'next/link'
+import { Key, Map, Package, Wifi, Calculator } from 'lucide-react'
 import { MOCK_COMPANY } from '@/lib/mock-data'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
@@ -68,6 +69,32 @@ export default function SettingsPage() {
               endpoint="POST /api/ingest/location"
               payload='{ "tracker_id": "bt-003", "lat": 36.16, "lng": -86.78, "accuracy": 15 }'
             />
+          </div>
+        </section>
+
+        {/* QuickBooks */}
+        <section className="bg-white rounded-xl border border-slate-200 overflow-hidden shadow-sm">
+          <div className="px-4 py-3 border-b border-slate-100 flex items-center gap-2">
+            <Calculator className="h-4 w-4 text-slate-400" />
+            <h2 className="font-semibold text-sm text-slate-700">QuickBooks Online</h2>
+          </div>
+          <div className="p-4 space-y-3">
+            <p className="text-xs text-slate-500">
+              Sync assets as fixed assets, push equipment-usage invoices per job site, and record
+              service costs as expenses — automatically.
+            </p>
+            <div className="flex gap-2">
+              <Link href="/accounting" className="flex-1">
+                <span className="block text-center text-sm font-medium bg-amber-500 text-white rounded-lg py-2.5 hover:bg-amber-600 transition-colors">
+                  Open Accounting
+                </span>
+              </Link>
+              <a href="/api/qbo/connect" className="flex-1">
+                <span className="block text-center text-sm font-medium border border-slate-300 text-slate-700 rounded-lg py-2.5 hover:bg-slate-50 transition-colors">
+                  Connect QuickBooks
+                </span>
+              </a>
+            </div>
           </div>
         </section>
 

--- a/app/api/ingest/flespi/route.ts
+++ b/app/api/ingest/flespi/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createHmac, timingSafeEqual } from 'crypto'
 import { normalizeMessage, type FlespiMessage, type NormalizedReading } from '@/lib/flespi'
 
-const HMAC_SECRET = 'trackflow-flespi-token-comparison'
+const HMAC_SECRET = 'hammertrack-flespi-token-comparison'
 
 function verifyToken(request: NextRequest): boolean {
   const expected = process.env.FLESPI_WEBHOOK_TOKEN

--- a/app/api/ingest/flespi/route.ts
+++ b/app/api/ingest/flespi/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'crypto'
+import { normalizeMessage, type FlespiMessage, type NormalizedReading } from '@/lib/flespi'
+
+const HMAC_SECRET = 'trackflow-flespi-token-comparison'
+
+function verifyToken(request: NextRequest): boolean {
+  const expected = process.env.FLESPI_WEBHOOK_TOKEN
+  if (!expected) return true // demo mode — accept
+
+  const token = request.headers.get('x-flespi-token') ?? ''
+  if (!token) return false
+  try {
+    const a = createHmac('sha256', HMAC_SECRET).update(token).digest()
+    const b = createHmac('sha256', HMAC_SECRET).update(expected).digest()
+    return timingSafeEqual(a, b)
+  } catch {
+    return false
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!verifyToken(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  // flespi posts either a single message or an array of messages.
+  const messages: FlespiMessage[] = Array.isArray(body) ? body : [body as FlespiMessage]
+  const normalized = messages.map(normalizeMessage).filter((r): r is NormalizedReading => r !== null)
+
+  if (normalized.length === 0) {
+    return NextResponse.json({ error: 'No valid messages (need ident + position)' }, { status: 422 })
+  }
+
+  const isMock = !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL === 'https://your-project.supabase.co'
+
+  if (isMock) {
+    return NextResponse.json({
+      ok: true,
+      mode: 'demo',
+      accepted: normalized.length,
+      beacons_seen: normalized.reduce((n, r) => n + r.beacons.length, 0),
+      message: 'Demo mode: flespi data parsed (not persisted)',
+    })
+  }
+
+  const { createServiceClient } = await import('@/lib/supabase-server')
+  const supabase = createServiceClient()
+
+  let persisted = 0
+  for (const r of normalized) {
+    const { data: asset } = await supabase
+      .from('assets')
+      .select('id, company_id')
+      .eq('tracker_id', r.tracker_id)
+      .single()
+    if (!asset) continue
+
+    await supabase.from('asset_locations').insert({
+      asset_id: asset.id,
+      company_id: asset.company_id,
+      lat: r.lat,
+      lng: r.lng,
+      speed: r.speed,
+      heading: r.heading,
+      battery: r.battery,
+      accuracy: null,
+      timestamp: r.timestamp,
+      raw: { source: 'flespi' },
+    })
+    persisted++
+
+    // Associate detected BLE beacons (tools) with this gateway asset.
+    // Convention: a tool asset's `tracker_id` is set to its BLE beacon ID/MAC
+    // (the same value the gateway reports in ble.beacons[].id). Register tools
+    // with their beacon UUID as the tracker_id for this lookup to match.
+    for (const beacon of r.beacons) {
+      const { data: tool } = await supabase
+        .from('assets')
+        .select('id')
+        .eq('company_id', asset.company_id)
+        .eq('tracker_id', beacon.id)
+        .single()
+      if (!tool) continue
+      await supabase.from('tool_associations').upsert(
+        {
+          company_id: asset.company_id,
+          tool_asset_id: tool.id,
+          gateway_asset_id: asset.id,
+          rssi: beacon.rssi,
+          last_seen: r.timestamp,
+        },
+        { onConflict: 'tool_asset_id' }
+      )
+    }
+  }
+
+  return NextResponse.json({ ok: true, persisted })
+}

--- a/app/api/ingest/location/route.ts
+++ b/app/api/ingest/location/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createHmac, timingSafeEqual } from 'crypto'
 import type { IngestLocationPayload } from '@/lib/types'
 
-const HMAC_SECRET = 'trackflow-api-key-comparison'
+const HMAC_SECRET = 'hammertrack-api-key-comparison'
 
 function verifyApiKey(request: NextRequest): boolean {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY

--- a/app/api/ingest/obd2/route.ts
+++ b/app/api/ingest/obd2/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createHmac, timingSafeEqual } from 'crypto'
 import type { IngestObd2Payload } from '@/lib/types'
 
-const HMAC_SECRET = 'trackflow-api-key-comparison'
+const HMAC_SECRET = 'hammertrack-api-key-comparison'
 
 function verifyApiKey(request: NextRequest): boolean {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY

--- a/app/api/qbo/callback/route.ts
+++ b/app/api/qbo/callback/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isQboConfigured, exchangeCodeForTokens } from '@/lib/qbo'
+
+export async function GET(request: NextRequest) {
+  const baseUrl = new URL('/accounting', request.url)
+
+  if (!isQboConfigured) {
+    baseUrl.searchParams.set('demo', '1')
+    return NextResponse.redirect(baseUrl)
+  }
+
+  const code = request.nextUrl.searchParams.get('code')
+  const realmId = request.nextUrl.searchParams.get('realmId')
+  const state = request.nextUrl.searchParams.get('state')
+  const savedState = request.cookies.get('qbo_oauth_state')?.value
+
+  if (!code || !realmId) {
+    baseUrl.searchParams.set('error', 'missing_code')
+    return NextResponse.redirect(baseUrl)
+  }
+  if (!state || state !== savedState) {
+    baseUrl.searchParams.set('error', 'state_mismatch')
+    return NextResponse.redirect(baseUrl)
+  }
+
+  try {
+    const tokens = await exchangeCodeForTokens(code)
+    const isMock = !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      process.env.NEXT_PUBLIC_SUPABASE_URL === 'https://your-project.supabase.co'
+
+    if (!isMock) {
+      const { createServiceClient } = await import('@/lib/supabase-server')
+      const supabase = createServiceClient()
+      // NOTE: in a full build, resolve company_id from the authenticated session.
+      await supabase.from('qbo_connections').upsert({
+        realm_id: realmId,
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+        connected_at: new Date().toISOString(),
+      })
+    }
+
+    baseUrl.searchParams.set('connected', '1')
+    const res = NextResponse.redirect(baseUrl)
+    res.cookies.delete('qbo_oauth_state')
+    return res
+  } catch {
+    baseUrl.searchParams.set('error', 'token_exchange_failed')
+    return NextResponse.redirect(baseUrl)
+  }
+}

--- a/app/api/qbo/connect/route.ts
+++ b/app/api/qbo/connect/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { randomBytes } from 'crypto'
+import { isQboConfigured, buildAuthorizeUrl } from '@/lib/qbo'
+
+export async function GET() {
+  if (!isQboConfigured) {
+    // Demo mode: nothing to connect to — bounce back to the accounting page.
+    return NextResponse.redirect(
+      new URL('/accounting?demo=1', process.env.QBO_REDIRECT_URI ?? 'http://localhost:3000')
+    )
+  }
+
+  const state = randomBytes(16).toString('hex')
+  const res = NextResponse.redirect(buildAuthorizeUrl(state))
+  // CSRF protection: store state in a short-lived cookie to verify on callback.
+  res.cookies.set('qbo_oauth_state', state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: 600,
+    path: '/',
+  })
+  return res
+}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,144 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { Check, MapPin, Bell, Wrench, Calculator, ShieldAlert, ArrowRight } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'HammerTrack — Know where every truck, machine & tool is. Right now.',
+  description:
+    'Put your whole fleet on one map and get a text the second something moves when it shouldn\'t. Half the price of Tenna, set up in a day. Start a free 30-day pilot.',
+}
+
+const FEATURES = [
+  { icon: MapPin, title: 'Whole fleet, one map', body: 'Trucks, heavy equipment, and Bluetooth-tagged tools — live, clustered, mobile-first.' },
+  { icon: ShieldAlert, title: 'After-hours theft alerts', body: 'Get a text the moment a machine moves outside work hours or leaves the jobsite.' },
+  { icon: Wrench, title: 'Maintenance built in', body: 'Service schedules by engine hours, mileage, or days. Never miss an oil change again.' },
+  { icon: Calculator, title: 'QuickBooks native', body: 'Auto-allocate equipment cost to job sites and bill usage. Your CFO will love you.' },
+]
+
+const VS_TENNA = [
+  ['$0 setup fees', 'Tenna: $500+ setup'],
+  ['Bluetooth tools included', 'Tenna: paid add-on'],
+  ['QuickBooks built in', 'Tenna: enterprise only'],
+  ['~$3–8 / asset / mo', 'Tenna: $15–25 / asset / mo'],
+]
+
+export default function DemoLandingPage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white">
+      {/* Nav */}
+      <header className="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between">
+        <Link href="/demo" className="flex items-center gap-2">
+          <div className="w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
+            <MapPin className="h-4 w-4 text-white" />
+          </div>
+          <span className="font-bold tracking-wider uppercase text-amber-400">HammerTrack</span>
+        </Link>
+        <div className="flex items-center gap-4">
+          <Link href="/pricing" className="text-sm text-slate-300 hover:text-white">Pricing</Link>
+          <Link href="/login" className="text-sm text-slate-300 hover:text-white">Sign in</Link>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <section className="max-w-5xl mx-auto px-4 pt-8 pb-16 grid md:grid-cols-2 gap-10 items-center">
+        <div>
+          <span className="inline-flex items-center gap-2 bg-red-500/10 text-red-300 border border-red-500/30 px-3 py-1 rounded-full text-xs font-bold">
+            <ShieldAlert className="h-3.5 w-3.5" /> THEFT ALERT — Skid Steer #3 moved at 2:14 AM
+          </span>
+          <h1 className="text-4xl md:text-5xl font-extrabold leading-tight mt-5">
+            Your $80K excavator just left the jobsite at 2 AM.
+            <span className="text-amber-400"> Would you know?</span>
+          </h1>
+          <p className="text-slate-300 mt-5 text-lg">
+            HammerTrack puts every truck, machine, and power tool on one map — and texts you
+            the second something moves when it shouldn&apos;t. Half the price of Tenna.
+            Set up in a day, no install crew.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 mt-8">
+            <Link
+              href="/register"
+              className="bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl px-6 py-3.5 text-center inline-flex items-center justify-center gap-2 transition-colors"
+            >
+              Start Free 30-Day Pilot <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/map"
+              className="bg-slate-800 hover:bg-slate-700 text-white font-semibold rounded-xl px-6 py-3.5 text-center border border-slate-700 transition-colors"
+            >
+              See the live demo →
+            </Link>
+          </div>
+          <p className="text-xs text-slate-500 mt-3">No credit card. We ship the trackers. Cancel anytime.</p>
+        </div>
+
+        {/* Map mock */}
+        <div className="relative">
+          <div className="aspect-[4/3] rounded-2xl bg-gradient-to-br from-slate-800 to-slate-950 border border-slate-700 overflow-hidden shadow-2xl relative">
+            <div className="absolute top-4 left-4 bg-slate-900/70 backdrop-blur text-xs font-bold px-3 py-1.5 rounded-lg border border-slate-700">
+              🔴 After-hours movement — Skid Steer #3
+            </div>
+            {/* pins */}
+            <span className="absolute w-3 h-3 rounded-full bg-amber-500 shadow-lg" style={{ top: '30%', left: '22%' }} />
+            <span className="absolute w-3 h-3 rounded-full bg-amber-500 shadow-lg" style={{ top: '55%', left: '40%' }} />
+            <span className="absolute w-3 h-3 rounded-full bg-teal-400 shadow-lg" style={{ top: '38%', left: '62%' }} />
+            <span className="absolute w-3 h-3 rounded-full bg-teal-400 shadow-lg" style={{ top: '68%', left: '74%' }} />
+            <span className="absolute w-4 h-4 rounded-full bg-red-500 shadow-lg ring-4 ring-red-500/30 animate-pulse" style={{ top: '20%', left: '80%' }} />
+            <span className="absolute w-3 h-3 rounded-full bg-amber-500 shadow-lg" style={{ top: '75%', left: '28%' }} />
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="max-w-5xl mx-auto px-4 py-12">
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {FEATURES.map(({ icon: Icon, title, body }) => (
+            <div key={title} className="bg-slate-800 rounded-2xl p-5 border border-slate-700">
+              <div className="w-10 h-10 rounded-lg bg-amber-500/15 flex items-center justify-center mb-3">
+                <Icon className="h-5 w-5 text-amber-400" />
+              </div>
+              <h3 className="font-bold">{title}</h3>
+              <p className="text-sm text-slate-400 mt-1">{body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* vs Tenna */}
+      <section className="max-w-3xl mx-auto px-4 py-8">
+        <h2 className="text-2xl font-bold text-center mb-6">Why contractors switch from Tenna</h2>
+        <div className="grid sm:grid-cols-2 gap-3">
+          {VS_TENNA.map(([us, them]) => (
+            <div key={us} className="flex items-start gap-2 bg-slate-800/50 rounded-xl px-4 py-3 border border-slate-700">
+              <Check className="h-5 w-5 text-green-400 flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="text-sm font-medium text-white">{us}</p>
+                <p className="text-xs text-slate-500 line-through">{them}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="max-w-5xl mx-auto px-4 py-16 text-center">
+        <div className="bg-gradient-to-br from-amber-500 to-orange-600 rounded-3xl p-10">
+          <Bell className="h-8 w-8 mx-auto mb-3" />
+          <h2 className="text-3xl font-extrabold">Stop guessing where your gear is.</h2>
+          <p className="text-white/90 mt-2 max-w-xl mx-auto">
+            Start a free 30-day pilot. We ship you 5 trackers, you put your whole site on the map.
+          </p>
+          <Link
+            href="/register"
+            className="inline-flex items-center justify-center gap-2 bg-slate-900 text-white font-bold rounded-xl px-8 py-3.5 mt-6 hover:bg-slate-800 transition-colors"
+          >
+            Start Free Pilot <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+
+      <footer className="border-t border-slate-800 py-8 text-center text-xs text-slate-500">
+        HammerTrack · hammertrack.ai · Asset tracking for construction
+      </footer>
+    </div>
+  )
+}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -137,7 +137,7 @@ export default function DemoLandingPage() {
       </section>
 
       <footer className="border-t border-slate-800 py-8 text-center text-xs text-slate-500">
-        HammerTrack · hammertrack.ai · Asset tracking for construction
+        HammerTrack · hammertrackai.com · Asset tracking for construction
       </footer>
     </div>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,10 +5,10 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'TrackFlow — Asset Tracking for Construction',
+  title: 'HammerTrack — Asset Tracking for Construction',
   description: 'Real-time GPS tracking for vehicles, equipment, personnel, and small tools. Built for construction companies.',
   manifest: '/manifest.json',
-  appleWebApp: { capable: true, statusBarStyle: 'default', title: 'TrackFlow' },
+  appleWebApp: { capable: true, statusBarStyle: 'default', title: 'HammerTrack' },
 }
 
 export const viewport: Viewport = {

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -56,7 +56,7 @@ export default function PricingPage() {
           <div className="w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
             <Map className="h-4 w-4 text-white" />
           </div>
-          <span className="font-bold tracking-wider uppercase text-amber-400">TrackFlow</span>
+          <span className="font-bold tracking-wider uppercase text-amber-400">HammerTrack</span>
         </Link>
         <Link href="/login" className="text-sm text-slate-300 hover:text-white">Sign in</Link>
       </header>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link'
+import { Check, Map } from 'lucide-react'
+
+const TIERS = [
+  {
+    name: 'Starter',
+    price: '$3',
+    unit: '/asset/mo',
+    blurb: 'For small crews getting started.',
+    cta: 'Start free trial',
+    highlight: false,
+    features: [
+      'Live GPS map', 'Bluetooth tool tracking', 'Geofences & alerts',
+      'After-hours theft alerts', 'Up to 25 assets', 'Email support',
+    ],
+  },
+  {
+    name: 'Pro',
+    price: '$5',
+    unit: '/asset/mo',
+    blurb: 'For growing contractors.',
+    cta: 'Start free trial',
+    highlight: true,
+    features: [
+      'Everything in Starter', 'QuickBooks integration', 'Maintenance & service records',
+      'Utilization & job-site reports', 'Equipment usage billing', 'Unlimited assets', 'Priority support',
+    ],
+  },
+  {
+    name: 'Fleet',
+    price: 'Custom',
+    unit: '',
+    blurb: 'For large fleets & multi-site.',
+    cta: 'Contact us',
+    highlight: false,
+    features: [
+      'Everything in Pro', 'Dedicated onboarding', 'Custom integrations',
+      'SLA & phone support', 'Volume hardware pricing',
+    ],
+  },
+]
+
+const VS_TENNA = [
+  ['$0 setup fees', 'Tenna: $500+ setup'],
+  ['Bluetooth tools included', 'Tenna: paid add-on'],
+  ['QuickBooks built in', 'Tenna: enterprise only'],
+  ['Self-serve in minutes', 'Tenna: sales-led onboarding'],
+  ['~$1–3/asset hardware data', 'Tenna: $15–25/asset/mo'],
+]
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-slate-900 text-white">
+      <header className="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
+            <Map className="h-4 w-4 text-white" />
+          </div>
+          <span className="font-bold tracking-wider uppercase text-amber-400">TrackFlow</span>
+        </Link>
+        <Link href="/login" className="text-sm text-slate-300 hover:text-white">Sign in</Link>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 pb-20">
+        <div className="text-center py-10">
+          <h1 className="text-3xl md:text-4xl font-bold">Asset tracking that pays for itself</h1>
+          <p className="text-slate-400 mt-3 max-w-xl mx-auto">
+            Everything Tenna does — vehicles, equipment, Bluetooth tools — at a fraction of the price, with QuickBooks built in.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-4">
+          {TIERS.map(tier => (
+            <div
+              key={tier.name}
+              className={`rounded-2xl p-6 flex flex-col ${
+                tier.highlight ? 'bg-white text-slate-900 ring-2 ring-amber-500 shadow-2xl' : 'bg-slate-800 text-white'
+              }`}
+            >
+              {tier.highlight && (
+                <span className="self-start bg-amber-500 text-white text-xs font-bold px-2 py-0.5 rounded-full mb-2">
+                  MOST POPULAR
+                </span>
+              )}
+              <h2 className="text-lg font-bold">{tier.name}</h2>
+              <p className={`text-sm mb-4 ${tier.highlight ? 'text-slate-500' : 'text-slate-400'}`}>{tier.blurb}</p>
+              <div className="mb-4">
+                <span className="text-3xl font-bold">{tier.price}</span>
+                <span className={tier.highlight ? 'text-slate-500' : 'text-slate-400'}>{tier.unit}</span>
+              </div>
+              <ul className="space-y-2 flex-1">
+                {tier.features.map(f => (
+                  <li key={f} className="flex items-start gap-2 text-sm">
+                    <Check className={`h-4 w-4 mt-0.5 flex-shrink-0 ${tier.highlight ? 'text-amber-500' : 'text-amber-400'}`} />
+                    <span className={tier.highlight ? 'text-slate-700' : 'text-slate-300'}>{f}</span>
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href="/register"
+                className={`mt-6 text-center font-semibold rounded-lg py-2.5 transition-colors ${
+                  tier.highlight ? 'bg-amber-500 text-white hover:bg-amber-600' : 'bg-slate-700 text-white hover:bg-slate-600'
+                }`}
+              >
+                {tier.cta}
+              </Link>
+            </div>
+          ))}
+        </div>
+
+        <section className="mt-12 bg-slate-800 rounded-2xl p-6">
+          <h3 className="font-bold text-lg mb-4 text-center">Why contractors switch from Tenna</h3>
+          <div className="grid sm:grid-cols-2 gap-3 max-w-2xl mx-auto">
+            {VS_TENNA.map(([us, them]) => (
+              <div key={us} className="flex items-start gap-2">
+                <Check className="h-5 w-5 text-green-400 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-sm font-medium text-white">{us}</p>
+                  <p className="text-xs text-slate-400 line-through">{them}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/components/accounting/AccountingView.tsx
+++ b/components/accounting/AccountingView.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useState } from 'react'
+import { Check, FileText, RefreshCw, Link2, Building2, X } from 'lucide-react'
+import type { Asset, Geofence, QboConnection, QboInvoicePreview } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { formatRelativeTime } from '@/lib/utils'
+
+interface AccountingViewProps {
+  connection: QboConnection
+  demo: boolean
+  assets: Asset[]
+  geofences: Geofence[]
+  invoicesByFence: Record<string, QboInvoicePreview>
+}
+
+const TYPE_EMOJI: Record<string, string> = {
+  vehicle: '🚛', equipment: '🏗️', personnel: '👷', tool: '🔧',
+}
+
+export function AccountingView({ connection, demo, assets, geofences, invoicesByFence }: AccountingViewProps) {
+  const [preview, setPreview] = useState<QboInvoicePreview | null>(null)
+  const [syncing, setSyncing] = useState(false)
+  const [synced, setSynced] = useState(false)
+
+  const billableAssets = assets.filter(a => a.type === 'vehicle' || a.type === 'equipment')
+
+  const handleSync = () => {
+    setSyncing(true)
+    setTimeout(() => { setSyncing(false); setSynced(true) }, 900)
+  }
+
+  return (
+    <div className="h-full overflow-auto pb-[70px] md:pb-0">
+      <div className="p-4 border-b border-slate-100 bg-white sticky top-0 z-10 flex items-center gap-3">
+        <h1 className="text-xl font-bold text-slate-900">Accounting</h1>
+        <Badge variant="success" className="flex items-center gap-1">
+          <Check className="h-3 w-3" /> QuickBooks {demo ? 'Connected (Demo)' : 'Connected'}
+        </Badge>
+      </div>
+
+      <div className="p-4 space-y-6 max-w-2xl">
+        {/* Connection card */}
+        <section className="bg-white rounded-xl border border-slate-200 p-4 shadow-sm">
+          <div className="flex items-center gap-3">
+            <div className="w-11 h-11 rounded-lg bg-green-50 flex items-center justify-center flex-shrink-0">
+              <Building2 className="h-6 w-6 text-green-600" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-semibold text-slate-900">{connection.company_name}</p>
+              <p className="text-xs text-slate-400">
+                Realm {connection.realm_id} · connected {formatRelativeTime(connection.connected_at)}
+              </p>
+            </div>
+          </div>
+          {demo && (
+            <p className="mt-3 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-2">
+              Demo connection. Add your Intuit app credentials (QBO_CLIENT_ID) to connect a real QuickBooks company.
+            </p>
+          )}
+        </section>
+
+        {/* Asset → QBO item mapping */}
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">Assets → QuickBooks Items</h2>
+            <Button size="sm" variant="outline" onClick={handleSync} disabled={syncing} className="gap-1">
+              <RefreshCw className={`h-3.5 w-3.5 ${syncing ? 'animate-spin' : ''}`} />
+              {synced ? 'Synced' : 'Sync'}
+            </Button>
+          </div>
+          <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 shadow-sm">
+            {billableAssets.map(a => (
+              <div key={a.id} className="p-3 flex items-center gap-3 text-sm">
+                <span className="text-lg">{TYPE_EMOJI[a.type]}</span>
+                <span className="flex-1 text-slate-800 truncate">{a.name}</span>
+                <Link2 className="h-3.5 w-3.5 text-slate-300" />
+                <span className="text-slate-500 text-xs truncate">Fixed Asset: {a.name}</span>
+                {synced && <Check className="h-4 w-4 text-green-500 flex-shrink-0" />}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Job sites → invoices */}
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">Job Sites → Equipment Billing</h2>
+          <div className="bg-white rounded-xl border border-slate-200 divide-y divide-slate-100 shadow-sm">
+            {geofences.map(g => {
+              const inv = invoicesByFence[g.id]
+              const hasBillable = inv && inv.lines.length > 0
+              return (
+                <div key={g.id} className="p-4 flex items-center gap-3">
+                  <div className="w-3 h-3 rounded-sm flex-shrink-0" style={{ backgroundColor: g.color }} />
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-slate-900 text-sm truncate">{g.name}</p>
+                    <p className="text-xs text-slate-400">
+                      {hasBillable ? `${inv.lines.length} billable asset(s) · $${inv.total.toLocaleString()}` : 'No billable usage'}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant={hasBillable ? 'default' : 'outline'}
+                    disabled={!hasBillable}
+                    onClick={() => inv && setPreview(inv)}
+                    className="gap-1 flex-shrink-0"
+                  >
+                    <FileText className="h-3.5 w-3.5" /> Invoice
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+          <p className="text-xs text-slate-400 text-center">
+            Invoices are built from utilization × equipment hourly rates and pushed to QuickBooks.
+          </p>
+        </section>
+      </div>
+
+      {/* Invoice preview modal */}
+      <Dialog open={!!preview} onOpenChange={(o) => !o && setPreview(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Equipment Usage Invoice</DialogTitle>
+          </DialogHeader>
+          {preview && (
+            <div className="space-y-4 pt-2">
+              <div className="text-sm">
+                <span className="text-slate-400">Customer / Job:</span>{' '}
+                <span className="font-medium text-slate-900">{preview.customer}</span>
+              </div>
+              <div className="border border-slate-200 rounded-lg overflow-hidden">
+                {preview.lines.map((l, i) => (
+                  <div key={i} className="p-3 border-b border-slate-100 last:border-0 flex justify-between gap-3 text-sm">
+                    <span className="text-slate-700 flex-1">{l.description}</span>
+                    <span className="font-medium text-slate-900 flex-shrink-0">${l.amount.toLocaleString()}</span>
+                  </div>
+                ))}
+                <div className="p-3 bg-slate-50 flex justify-between font-semibold text-slate-900">
+                  <span>Total</span>
+                  <span>${preview.total.toLocaleString()}</span>
+                </div>
+              </div>
+              <div className="flex gap-3">
+                <Button variant="outline" className="flex-1" onClick={() => setPreview(null)}>
+                  <X className="h-4 w-4 mr-1" /> Close
+                </Button>
+                <Button className="flex-1" onClick={() => setPreview(null)}>
+                  <Check className="h-4 w-4 mr-1" /> Push to QuickBooks
+                </Button>
+              </div>
+              {demo && <p className="text-xs text-amber-600 text-center">Demo: invoice preview only — not sent.</p>}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/components/alerts/AlertList.tsx
+++ b/components/alerts/AlertList.tsx
@@ -10,13 +10,19 @@ const TRIGGER_LABELS: Record<AlertRule['trigger'], string> = {
   enter: 'Entered zone',
   exit: 'Exited zone',
   idle: 'Idle too long',
+  after_hours_movement: 'THEFT ALERT',
+  left_site: 'Left job site',
 }
 
 const TRIGGER_COLORS: Record<AlertRule['trigger'], 'default' | 'destructive' | 'secondary'> = {
   enter: 'default',
   exit: 'destructive',
   idle: 'secondary',
+  after_hours_movement: 'destructive',
+  left_site: 'destructive',
 }
+
+const CRITICAL_TRIGGERS: AlertRule['trigger'][] = ['after_hours_movement', 'left_site']
 
 interface AlertListProps {
   alerts: AlertEvent[]
@@ -75,17 +81,22 @@ export function AlertList({ alerts, onAcknowledge }: AlertListProps) {
 function AlertRow({ alert, onAcknowledge }: { alert: AlertEvent; onAcknowledge?: (id: string) => void }) {
   const trigger = alert.rule?.trigger ?? 'exit'
   const isUnread = !alert.acknowledged_at
+  const isCritical = CRITICAL_TRIGGERS.includes(trigger)
   const assetName = alert.asset?.name ?? 'Unknown Asset'
   const zoneName = alert.rule?.geofence?.name ?? 'Unknown Zone'
 
+  const rowBg = isCritical && isUnread
+    ? 'bg-red-50 border-l-4 border-red-500'
+    : isUnread ? 'bg-amber-50/60' : 'hover:bg-slate-50'
+
   return (
-    <div className={`flex items-start gap-3 p-4 transition-colors ${isUnread ? 'bg-amber-50/60' : 'hover:bg-slate-50'}`}>
+    <div className={`flex items-start gap-3 p-4 transition-colors ${rowBg}`}>
       <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5 ${
-        isUnread ? 'bg-amber-100' : 'bg-slate-100'
+        isCritical && isUnread ? 'bg-red-100' : isUnread ? 'bg-amber-100' : 'bg-slate-100'
       }`}>
         {trigger === 'idle'
           ? <Clock className={`h-4 w-4 ${isUnread ? 'text-amber-600' : 'text-slate-400'}`} />
-          : <AlertTriangle className={`h-4 w-4 ${isUnread ? 'text-amber-600' : 'text-slate-400'}`} />
+          : <AlertTriangle className={`h-4 w-4 ${isCritical && isUnread ? 'text-red-600' : isUnread ? 'text-amber-600' : 'text-slate-400'}`} />
         }
       </div>
 

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -1,47 +1,102 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Map, Package, Bell, Settings } from 'lucide-react'
+import { Map, Package, Bell, MoreHorizontal, Wrench, BarChart3, Calculator, Settings, Hexagon, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-const navItems = [
+const primaryItems = [
   { href: '/map', label: 'Map', icon: Map },
   { href: '/assets', label: 'Assets', icon: Package },
   { href: '/alerts', label: 'Alerts', icon: Bell },
+]
+
+const moreItems = [
+  { href: '/geofences', label: 'Geofences', icon: Hexagon },
+  { href: '/maintenance', label: 'Maintenance', icon: Wrench },
+  { href: '/reports', label: 'Reports', icon: BarChart3 },
+  { href: '/accounting', label: 'Accounting', icon: Calculator },
   { href: '/settings', label: 'Settings', icon: Settings },
 ]
 
 export function BottomNav({ alertCount = 0 }: { alertCount?: number }) {
   const pathname = usePathname()
+  const [moreOpen, setMoreOpen] = useState(false)
+  const moreActive = moreItems.some(i => pathname.startsWith(i.href))
+
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-slate-900 border-t border-slate-700 md:hidden safe-area-pb">
-      <div className="flex">
-        {navItems.map(({ href, label, icon: Icon }) => {
-          const active = pathname.startsWith(href)
-          const isAlerts = href === '/alerts'
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={cn(
-                'flex-1 flex flex-col items-center justify-center py-3 gap-1 text-xs font-medium transition-colors min-h-[60px]',
-                active ? 'text-amber-400' : 'text-slate-400 hover:text-slate-200'
-              )}
-            >
-              <span className="relative">
-                <Icon className="h-5 w-5" />
-                {isAlerts && alertCount > 0 && (
-                  <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] font-bold rounded-full min-w-[16px] h-4 flex items-center justify-center px-0.5">
-                    {alertCount > 9 ? '9+' : alertCount}
-                  </span>
+    <>
+      {moreOpen && (
+        <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={() => setMoreOpen(false)}>
+          <div
+            className="absolute bottom-[60px] left-0 right-0 bg-slate-900 border-t border-slate-700 rounded-t-2xl p-4 safe-area-pb"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-sm font-semibold text-slate-300">More</span>
+              <button onClick={() => setMoreOpen(false)} className="p-1 text-slate-400">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              {moreItems.map(({ href, label, icon: Icon }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  onClick={() => setMoreOpen(false)}
+                  className={cn(
+                    'flex flex-col items-center gap-1.5 py-3 rounded-xl text-xs font-medium',
+                    pathname.startsWith(href) ? 'bg-amber-500/20 text-amber-400' : 'text-slate-300 hover:bg-slate-800'
+                  )}
+                >
+                  <Icon className="h-5 w-5" />
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <nav className="fixed bottom-0 left-0 right-0 z-40 bg-slate-900 border-t border-slate-700 md:hidden safe-area-pb">
+        <div className="flex">
+          {primaryItems.map(({ href, label, icon: Icon }) => {
+            const active = pathname.startsWith(href)
+            const isAlerts = href === '/alerts'
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={cn(
+                  'flex-1 flex flex-col items-center justify-center py-3 gap-1 text-xs font-medium transition-colors min-h-[60px]',
+                  active ? 'text-amber-400' : 'text-slate-400 hover:text-slate-200'
                 )}
-              </span>
-              <span>{label}</span>
-            </Link>
-          )
-        })}
-      </div>
-    </nav>
+              >
+                <span className="relative">
+                  <Icon className="h-5 w-5" />
+                  {isAlerts && alertCount > 0 && (
+                    <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] font-bold rounded-full min-w-[16px] h-4 flex items-center justify-center px-0.5">
+                      {alertCount > 9 ? '9+' : alertCount}
+                    </span>
+                  )}
+                </span>
+                <span>{label}</span>
+              </Link>
+            )
+          })}
+          <button
+            onClick={() => setMoreOpen(v => !v)}
+            className={cn(
+              'flex-1 flex flex-col items-center justify-center py-3 gap-1 text-xs font-medium transition-colors min-h-[60px]',
+              moreActive || moreOpen ? 'text-amber-400' : 'text-slate-400 hover:text-slate-200'
+            )}
+          >
+            <MoreHorizontal className="h-5 w-5" />
+            <span>More</span>
+          </button>
+        </div>
+      </nav>
+    </>
   )
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Map, Package, Bell, Settings, Hexagon, LogOut } from 'lucide-react'
+import { Map, Package, Bell, Settings, Hexagon, LogOut, Wrench, BarChart3, Calculator } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const navItems = [
@@ -10,6 +10,9 @@ const navItems = [
   { href: '/assets', label: 'Assets', icon: Package },
   { href: '/geofences', label: 'Geofences', icon: Hexagon },
   { href: '/alerts', label: 'Alerts', icon: Bell },
+  { href: '/maintenance', label: 'Maintenance', icon: Wrench },
+  { href: '/reports', label: 'Reports', icon: BarChart3 },
+  { href: '/accounting', label: 'Accounting', icon: Calculator },
   { href: '/settings', label: 'Settings', icon: Settings },
 ]
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -22,7 +22,7 @@ interface SidebarProps {
   onSignOut?: () => void
 }
 
-export function Sidebar({ companyName = 'TrackFlow Demo', alertCount = 0, onSignOut }: SidebarProps) {
+export function Sidebar({ companyName = 'HammerTrack Demo', alertCount = 0, onSignOut }: SidebarProps) {
   const pathname = usePathname()
   return (
     <aside className="hidden md:flex flex-col w-56 bg-slate-900 text-white h-screen fixed left-0 top-0 z-40 border-r border-slate-700">
@@ -32,7 +32,7 @@ export function Sidebar({ companyName = 'TrackFlow Demo', alertCount = 0, onSign
             <Map className="h-4 w-4 text-white" />
           </div>
           <div>
-            <p className="text-xs font-bold text-amber-400 tracking-wider uppercase">TrackFlow</p>
+            <p className="text-xs font-bold text-amber-400 tracking-wider uppercase">HammerTrack</p>
             <p className="text-xs text-slate-400 truncate max-w-[120px]">{companyName}</p>
           </div>
         </div>

--- a/components/map/AssetPanel.tsx
+++ b/components/map/AssetPanel.tsx
@@ -23,10 +23,11 @@ const BATTERY_COLOR = (pct: number | null) => {
 
 interface AssetPanelProps {
   asset: AssetWithLocation
+  gateway?: { name: string; lastSeen: string }
   onClose: () => void
 }
 
-export function AssetPanel({ asset, onClose }: AssetPanelProps) {
+export function AssetPanel({ asset, gateway, onClose }: AssetPanelProps) {
   const loc = asset.location
   const meta = asset.metadata ?? {}
 
@@ -47,7 +48,7 @@ export function AssetPanel({ asset, onClose }: AssetPanelProps) {
               <X className="h-4 w-4" />
             </button>
           </div>
-          <AssetDetails asset={asset} loc={loc} meta={meta} />
+          <AssetDetails asset={asset} loc={loc} meta={meta} gateway={gateway} />
         </div>
       </div>
 
@@ -67,7 +68,7 @@ export function AssetPanel({ asset, onClose }: AssetPanelProps) {
             </button>
           </div>
           <div className="p-5 flex-1 overflow-y-auto">
-            <AssetDetails asset={asset} loc={loc} meta={meta} />
+            <AssetDetails asset={asset} loc={loc} meta={meta} gateway={gateway} />
           </div>
         </div>
       </div>
@@ -79,13 +80,25 @@ function AssetDetails({
   asset,
   loc,
   meta,
+  gateway,
 }: {
   asset: AssetWithLocation
   loc: AssetWithLocation['location']
   meta: Record<string, unknown>
+  gateway?: { name: string; lastSeen: string }
 }) {
   return (
     <div className="space-y-3">
+      {asset.type === 'tool' && gateway && (
+        <div className="bg-purple-50 border border-purple-200 rounded-lg p-3 flex items-center gap-2">
+          <Wifi className="h-4 w-4 text-purple-600 flex-shrink-0" />
+          <div className="text-sm">
+            <span className="text-purple-700">Currently with </span>
+            <span className="font-semibold text-purple-900">{gateway.name}</span>
+            <span className="text-purple-500 text-xs"> · {formatRelativeTime(gateway.lastSeen)}</span>
+          </div>
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-3">
         {loc?.battery !== null && loc?.battery !== undefined && (
           <StatTile

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -44,10 +44,11 @@ function buildGeoJSON(assets: AssetWithLocation[], filter: Set<AssetType>): GeoJ
 interface MapViewProps {
   assets: AssetWithLocation[]
   geofences: Geofence[]
+  toolGateways?: Record<string, { name: string; lastSeen: string }>
   onGeofenceSave?: (name: string, geometry: GeoJSON.Polygon, color: string) => void
 }
 
-export function MapView({ assets, geofences, onGeofenceSave }: MapViewProps) {
+export function MapView({ assets, geofences, toolGateways, onGeofenceSave }: MapViewProps) {
   const mapContainer = useRef<HTMLDivElement>(null)
   const map = useRef<maplibregl.Map | null>(null)
   const [selectedAsset, setSelectedAsset] = useState<AssetWithLocation | null>(null)
@@ -334,6 +335,7 @@ export function MapView({ assets, geofences, onGeofenceSave }: MapViewProps) {
       {selectedAsset && (
         <AssetPanel
           asset={selectedAsset}
+          gateway={toolGateways?.[selectedAsset.id]}
           onClose={() => setSelectedAsset(null)}
         />
       )}

--- a/lib/alerts-engine.ts
+++ b/lib/alerts-engine.ts
@@ -1,0 +1,123 @@
+import type { Asset, AssetLocation, AlertRule, Geofence, Company } from './types'
+
+export interface EvaluatedAlert {
+  rule_id: string
+  asset_id: string
+  trigger: AlertRule['trigger']
+  geofence_id: string
+  reason: string
+  severity: 'critical' | 'warning' | 'info'
+}
+
+/** Ray-casting point-in-polygon test (lng/lat). */
+export function pointInPolygon(point: [number, number], polygon: [number, number][]): boolean {
+  let inside = false
+  const [x, y] = point
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const [xi, yi] = polygon[i]
+    const [xj, yj] = polygon[j]
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+/** True when `date` falls outside the company's configured working hours. */
+export function isAfterHours(date: Date, company: Pick<Company, 'work_start' | 'work_end' | 'work_days'>): boolean {
+  const day = date.getDay()
+  if (!company.work_days.includes(day)) return true
+  const [sh, sm] = company.work_start.split(':').map(Number)
+  const [eh, em] = company.work_end.split(':').map(Number)
+  const mins = date.getHours() * 60 + date.getMinutes()
+  return mins < sh * 60 + sm || mins >= eh * 60 + em
+}
+
+const MOVING_SPEED_MPH = 3
+
+interface EvalInput {
+  assets: Asset[]
+  locations: Record<string, AssetLocation> // asset_id -> latest location
+  rules: AlertRule[]
+  geofences: Geofence[]
+  company: Pick<Company, 'work_start' | 'work_end' | 'work_days'>
+  now?: Date
+}
+
+/**
+ * Pure evaluation of which alerts should fire given current state. Used both to
+ * drive the live alerts list and (in production) a scheduled checker.
+ */
+export function evaluateAlerts(input: EvalInput): EvaluatedAlert[] {
+  const { assets, locations, rules, geofences, company, now = new Date() } = input
+  const out: EvaluatedAlert[] = []
+
+  for (const rule of rules) {
+    if (!rule.active) continue
+    const fence = geofences.find(g => g.id === rule.geofence_id)
+    if (!fence) continue
+    const ring = fence.geometry.coordinates[0] as [number, number][]
+
+    const targets = rule.asset_id
+      ? assets.filter(a => a.id === rule.asset_id)
+      : assets
+
+    for (const asset of targets) {
+      const loc = locations[asset.id]
+      if (!loc) continue
+      const inside = pointInPolygon([loc.lng, loc.lat], ring)
+      const moving = (loc.speed ?? 0) > MOVING_SPEED_MPH
+
+      switch (rule.trigger) {
+        case 'after_hours_movement':
+          if (moving && isAfterHours(now, company)) {
+            out.push({
+              rule_id: rule.id, asset_id: asset.id, trigger: rule.trigger,
+              geofence_id: fence.id, severity: 'critical',
+              reason: `${asset.name} is moving outside work hours — possible theft`,
+            })
+          }
+          break
+        case 'left_site':
+          if (!inside && moving) {
+            out.push({
+              rule_id: rule.id, asset_id: asset.id, trigger: rule.trigger,
+              geofence_id: fence.id, severity: 'critical',
+              reason: `${asset.name} left ${fence.name}`,
+            })
+          }
+          break
+        case 'exit':
+          if (!inside) {
+            out.push({
+              rule_id: rule.id, asset_id: asset.id, trigger: rule.trigger,
+              geofence_id: fence.id, severity: 'warning',
+              reason: `${asset.name} exited ${fence.name}`,
+            })
+          }
+          break
+        case 'enter':
+          if (inside) {
+            out.push({
+              rule_id: rule.id, asset_id: asset.id, trigger: rule.trigger,
+              geofence_id: fence.id, severity: 'info',
+              reason: `${asset.name} entered ${fence.name}`,
+            })
+          }
+          break
+        case 'idle': {
+          const idleMins = (now.getTime() - new Date(loc.timestamp).getTime()) / 60000
+          if (rule.idle_minutes && idleMins >= rule.idle_minutes) {
+            out.push({
+              rule_id: rule.id, asset_id: asset.id, trigger: rule.trigger,
+              geofence_id: fence.id, severity: 'warning',
+              reason: `${asset.name} idle for ${Math.round(idleMins)}m`,
+            })
+          }
+          break
+        }
+      }
+    }
+  }
+
+  return out
+}

--- a/lib/db/maintenance.ts
+++ b/lib/db/maintenance.ts
@@ -1,0 +1,81 @@
+import type { MaintenanceSchedule, ServiceRecord } from '../types'
+import { MOCK_MAINTENANCE_SCHEDULES, MOCK_SERVICE_RECORDS, MOCK_CURRENT_READINGS } from '../mock-data'
+
+const isMock = !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL === 'https://your-project.supabase.co'
+
+export interface MaintenanceStatus extends MaintenanceSchedule {
+  current_value: number
+  used: number // amount consumed since last service
+  remaining: number // until due (negative = overdue)
+  pct: number // 0-100+ progress toward due
+  status: 'ok' | 'due_soon' | 'overdue'
+}
+
+export async function getMaintenanceSchedules(companyId: string): Promise<MaintenanceSchedule[]> {
+  if (isMock) return MOCK_MAINTENANCE_SCHEDULES
+
+  const { createClient } = await import('../supabase-server')
+  const supabase = createClient()
+  const { data } = await supabase
+    .from('maintenance_schedules')
+    .select('*')
+    .eq('company_id', companyId)
+  return data ?? []
+}
+
+export async function getServiceRecords(companyId: string, assetId?: string): Promise<ServiceRecord[]> {
+  if (isMock) {
+    return assetId
+      ? MOCK_SERVICE_RECORDS.filter(r => r.asset_id === assetId)
+      : MOCK_SERVICE_RECORDS
+  }
+
+  const { createClient } = await import('../supabase-server')
+  const supabase = createClient()
+  let q = supabase.from('service_records').select('*').eq('company_id', companyId)
+  if (assetId) q = q.eq('asset_id', assetId)
+  const { data } = await q.order('service_date', { ascending: false })
+  return data ?? []
+}
+
+export async function getCurrentReadings(): Promise<Record<string, number>> {
+  // In production this comes from latest OBD2 odometer / engine-hour telemetry.
+  if (isMock) return MOCK_CURRENT_READINGS
+  return {}
+}
+
+export function computeStatus(
+  schedule: MaintenanceSchedule,
+  currentValue: number
+): MaintenanceStatus {
+  const used = schedule.interval_type === 'days'
+    ? daysSince(schedule.last_service_date)
+    : Math.max(0, currentValue - schedule.last_service_value)
+  const remaining = schedule.interval_value - used
+  const pct = schedule.interval_value > 0 ? (used / schedule.interval_value) * 100 : 0
+  const status: MaintenanceStatus['status'] =
+    remaining <= 0 ? 'overdue' : pct >= 85 ? 'due_soon' : 'ok'
+  return { ...schedule, current_value: currentValue, used, remaining, pct, status }
+}
+
+function daysSince(date: string | null): number {
+  if (!date) return 0
+  return Math.floor((Date.now() - new Date(date).getTime()) / (24 * 60 * 60 * 1000))
+}
+
+export async function createServiceRecord(
+  companyId: string,
+  payload: Omit<ServiceRecord, 'id' | 'company_id'>
+): Promise<ServiceRecord | null> {
+  if (isMock) return null
+
+  const { createClient } = await import('../supabase-server')
+  const supabase = createClient()
+  const { data } = await supabase
+    .from('service_records')
+    .insert({ ...payload, company_id: companyId })
+    .select()
+    .single()
+  return data
+}

--- a/lib/db/tools.ts
+++ b/lib/db/tools.ts
@@ -1,0 +1,57 @@
+import type { ToolAssociation, AssetWithLocation } from '../types'
+import { MOCK_TOOL_ASSOCIATIONS } from '../mock-data'
+
+const isMock = !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL === 'https://your-project.supabase.co'
+
+export async function getToolAssociations(companyId: string): Promise<ToolAssociation[]> {
+  if (isMock) return MOCK_TOOL_ASSOCIATIONS
+
+  const { createClient } = await import('../supabase-server')
+  const supabase = createClient()
+  const { data } = await supabase
+    .from('tool_associations')
+    .select('*')
+    .eq('company_id', companyId)
+  return data ?? []
+}
+
+/**
+ * Given the full asset list and the current tool→gateway associations, returns
+ * the gateway (truck/equipment) a given tool is currently detected by, if any.
+ */
+export function findGatewayForTool(
+  toolId: string,
+  associations: ToolAssociation[],
+  assets: AssetWithLocation[]
+): { gateway: AssetWithLocation; assoc: ToolAssociation } | null {
+  const assoc = associations.find(a => a.tool_asset_id === toolId)
+  if (!assoc) return null
+  const gateway = assets.find(a => a.id === assoc.gateway_asset_id)
+  if (!gateway) return null
+  return { gateway, assoc }
+}
+
+/**
+ * Tools usually have no GPS of their own — they inherit the location of the
+ * gateway (truck/equipment) that currently detects them over Bluetooth.
+ */
+export function resolveToolLocations(
+  assets: AssetWithLocation[],
+  associations: ToolAssociation[]
+): AssetWithLocation[] {
+  return assets.map(asset => {
+    if (asset.type !== 'tool' || asset.location) return asset
+    const match = findGatewayForTool(asset.id, associations, assets)
+    if (!match?.gateway.location) return asset
+    return {
+      ...asset,
+      location: {
+        ...match.gateway.location,
+        id: `inherited-${asset.id}`,
+        asset_id: asset.id,
+        timestamp: match.assoc.last_seen,
+      },
+    }
+  })
+}

--- a/lib/flespi.ts
+++ b/lib/flespi.ts
@@ -1,0 +1,79 @@
+/** A flespi message is a flat bag of telemetry params; field names vary by device. */
+export interface FlespiMessage {
+  ident?: string // device identifier (IMEI) — mapped to tracker_id
+  'device.id'?: number
+  'position.latitude'?: number
+  'position.longitude'?: number
+  'position.speed'?: number
+  'position.direction'?: number
+  'battery.level'?: number
+  'battery.voltage'?: number
+  'engine.ignition.status'?: boolean
+  'movement.status'?: boolean
+  timestamp?: number // unix seconds
+  // BLE beacons can arrive in several shapes depending on device/config:
+  'ble.beacons'?: Array<{ id?: string; mac?: string; rssi?: number }>
+  [key: string]: unknown
+}
+
+export interface NormalizedReading {
+  tracker_id: string
+  lat: number
+  lng: number
+  speed: number | null
+  heading: number | null
+  battery: number | null
+  timestamp: string
+  beacons: { id: string; rssi: number | null }[]
+}
+
+function voltageToPercent(v: number): number {
+  // Rough 3xAA Li (Oyster) / backup-cell mapping, clamped 0-100.
+  const pct = ((v - 3.3) / (4.2 - 3.3)) * 100
+  return Math.max(0, Math.min(100, Math.round(pct)))
+}
+
+/**
+ * Normalize a single flespi message into our internal reading shape, handling
+ * both Teltonika FMM130 and Digital Matter Oyster3 field conventions. Returns
+ * null when the message lacks a usable identifier or valid coordinates.
+ */
+export function normalizeMessage(msg: FlespiMessage): NormalizedReading | null {
+  const tracker_id = msg.ident ?? (msg['device.id'] != null ? String(msg['device.id']) : undefined)
+  const lat = msg['position.latitude']
+  const lng = msg['position.longitude']
+  if (!tracker_id || typeof lat !== 'number' || typeof lng !== 'number') return null
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null
+
+  let battery: number | null = null
+  if (typeof msg['battery.level'] === 'number') battery = Math.round(msg['battery.level'])
+  else if (typeof msg['battery.voltage'] === 'number') battery = voltageToPercent(msg['battery.voltage'])
+
+  const beacons: NormalizedReading['beacons'] = []
+  const rawBeacons = msg['ble.beacons']
+  if (Array.isArray(rawBeacons)) {
+    for (const b of rawBeacons) {
+      const id = b.id ?? b.mac
+      if (id) beacons.push({ id, rssi: typeof b.rssi === 'number' ? b.rssi : null })
+    }
+  }
+  // Also support flattened "ble.sensor.<n>.id" style fields.
+  for (const [k, v] of Object.entries(msg)) {
+    const m = k.match(/^ble\.sensor\.(\d+)\.(id|mac)$/)
+    if (m && typeof v === 'string') {
+      const rssi = msg[`ble.sensor.${m[1]}.rssi`]
+      beacons.push({ id: v, rssi: typeof rssi === 'number' ? rssi : null })
+    }
+  }
+
+  return {
+    tracker_id,
+    lat,
+    lng,
+    speed: typeof msg['position.speed'] === 'number' ? msg['position.speed'] : null,
+    heading: typeof msg['position.direction'] === 'number' ? msg['position.direction'] : null,
+    battery,
+    timestamp: msg.timestamp ? new Date(msg.timestamp * 1000).toISOString() : new Date().toISOString(),
+    beacons,
+  }
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,12 +1,19 @@
-import type { AssetWithLocation, Geofence, AlertEvent, AlertRule, Company } from './types'
+import type {
+  AssetWithLocation, Geofence, AlertEvent, AlertRule, Company,
+  ToolAssociation, MaintenanceSchedule, ServiceRecord, AssetUtilization,
+  QboConnection,
+} from './types'
 
 // Nashville, TN construction site area
 export const MOCK_COMPANY: Company = {
   id: 'mock-company-1',
-  name: 'Acme Construction Co.',
+  name: 'Dillard Construction Group',
   api_key: 'tf_demo_key_for_display_only',
   plan: 'pro',
   created_at: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
+  work_start: '07:00',
+  work_end: '17:00',
+  work_days: [1, 2, 3, 4, 5, 6], // Mon-Sat
 }
 
 export const MOCK_ASSETS: AssetWithLocation[] = [
@@ -166,6 +173,16 @@ export const MOCK_GEOFENCES: Geofence[] = [
 
 export const MOCK_ALERT_RULES: AlertRule[] = [
   {
+    id: 'rule-theft', company_id: 'mock-company-1',
+    geofence_id: 'fence-1', asset_id: null,
+    trigger: 'after_hours_movement', idle_minutes: null, active: true,
+  },
+  {
+    id: 'rule-leftsite', company_id: 'mock-company-1',
+    geofence_id: 'fence-1', asset_id: null,
+    trigger: 'left_site', idle_minutes: null, active: true,
+  },
+  {
     id: 'rule-1', company_id: 'mock-company-1',
     geofence_id: 'fence-1', asset_id: null,
     trigger: 'exit', idle_minutes: null, active: true,
@@ -184,12 +201,28 @@ export const MOCK_ALERT_RULES: AlertRule[] = [
 
 export const MOCK_ALERTS: AlertEvent[] = [
   {
+    id: 'evt-theft', company_id: 'mock-company-1',
+    rule_id: 'rule-theft', asset_id: 'asset-2',
+    triggered_at: new Date(Date.now() - 9 * 60000).toISOString(),
+    acknowledged_at: null,
+    asset: MOCK_ASSETS.find(a => a.id === 'asset-2'),
+    rule: { ...MOCK_ALERT_RULES[0], geofence: MOCK_GEOFENCES[0] },
+  },
+  {
+    id: 'evt-leftsite', company_id: 'mock-company-1',
+    rule_id: 'rule-leftsite', asset_id: 'asset-9',
+    triggered_at: new Date(Date.now() - 52 * 60000).toISOString(),
+    acknowledged_at: null,
+    asset: MOCK_ASSETS.find(a => a.id === 'asset-9'),
+    rule: { ...MOCK_ALERT_RULES[1], geofence: MOCK_GEOFENCES[0] },
+  },
+  {
     id: 'evt-1', company_id: 'mock-company-1',
     rule_id: 'rule-1', asset_id: 'asset-6',
     triggered_at: new Date(Date.now() - 25 * 60000).toISOString(),
     acknowledged_at: null,
     asset: MOCK_ASSETS.find(a => a.id === 'asset-6'),
-    rule: { ...MOCK_ALERT_RULES[0], geofence: MOCK_GEOFENCES[0] },
+    rule: { ...MOCK_ALERT_RULES[2], geofence: MOCK_GEOFENCES[0] },
   },
   {
     id: 'evt-2', company_id: 'mock-company-1',
@@ -197,7 +230,7 @@ export const MOCK_ALERTS: AlertEvent[] = [
     triggered_at: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
     acknowledged_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
     asset: MOCK_ASSETS.find(a => a.id === 'asset-2'),
-    rule: { ...MOCK_ALERT_RULES[2], geofence: MOCK_GEOFENCES[0] },
+    rule: { ...MOCK_ALERT_RULES[4], geofence: MOCK_GEOFENCES[0] },
   },
   {
     id: 'evt-3', company_id: 'mock-company-1',
@@ -205,7 +238,7 @@ export const MOCK_ALERTS: AlertEvent[] = [
     triggered_at: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
     acknowledged_at: new Date(Date.now() - 5.5 * 60 * 60 * 1000).toISOString(),
     asset: MOCK_ASSETS.find(a => a.id === 'asset-1'),
-    rule: { ...MOCK_ALERT_RULES[1], geofence: MOCK_GEOFENCES[1] },
+    rule: { ...MOCK_ALERT_RULES[3], geofence: MOCK_GEOFENCES[1] },
   },
   {
     id: 'evt-4', company_id: 'mock-company-1',
@@ -213,9 +246,121 @@ export const MOCK_ALERTS: AlertEvent[] = [
     triggered_at: new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(),
     acknowledged_at: null,
     asset: MOCK_ASSETS.find(a => a.id === 'asset-10'),
-    rule: { ...MOCK_ALERT_RULES[0], geofence: MOCK_GEOFENCES[0] },
+    rule: { ...MOCK_ALERT_RULES[2], geofence: MOCK_GEOFENCES[0] },
   },
 ]
 
 export const DEMO_MAP_CENTER: [number, number] = [-86.7816, 36.1635]
 export const DEMO_MAP_ZOOM = 14.5
+
+// ── v2: Bluetooth tool associations ──────────────────────────────────────────
+// The two tool assets (asset-4 Drill Kit, asset-8 Level & Survey Kit) are
+// detected by truck/equipment gateways via BLE.
+export const MOCK_TOOL_ASSOCIATIONS: ToolAssociation[] = [
+  {
+    id: 'assoc-1', company_id: 'mock-company-1',
+    tool_asset_id: 'asset-4', gateway_asset_id: 'asset-1', // Drill Kit in F-350 Truck #1
+    rssi: -62, last_seen: new Date(Date.now() - 6 * 60000).toISOString(),
+  },
+  {
+    id: 'assoc-2', company_id: 'mock-company-1',
+    tool_asset_id: 'asset-8', gateway_asset_id: 'asset-9', // Survey Kit on JD Backhoe
+    rssi: -74, last_seen: new Date(Date.now() - 14 * 60000).toISOString(),
+  },
+]
+
+// ── v2: Maintenance ───────────────────────────────────────────────────────────
+export const MOCK_MAINTENANCE_SCHEDULES: MaintenanceSchedule[] = [
+  {
+    id: 'maint-1', company_id: 'mock-company-1', asset_id: 'asset-2',
+    interval_type: 'engine_hours', interval_value: 250, last_service_value: 1180,
+    last_service_date: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString(),
+    description: 'Hydraulic fluid & filter service',
+  },
+  {
+    id: 'maint-2', company_id: 'mock-company-1', asset_id: 'asset-1',
+    interval_type: 'mileage', interval_value: 5000, last_service_value: 38000,
+    last_service_date: new Date(Date.now() - 70 * 24 * 60 * 60 * 1000).toISOString(),
+    description: 'Oil change & tire rotation',
+  },
+  {
+    id: 'maint-3', company_id: 'mock-company-1', asset_id: 'asset-9',
+    interval_type: 'engine_hours', interval_value: 500, last_service_value: 2100,
+    last_service_date: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+    description: 'Annual inspection & greasing',
+  },
+]
+
+// Current readings used to compute due/overdue (engine hours or odometer)
+export const MOCK_CURRENT_READINGS: Record<string, number> = {
+  'asset-1': 42600, // miles — 4600 since last service (due soon at 5000)
+  'asset-2': 1455,  // engine hours — 275 since last service (OVERDUE, interval 250)
+  'asset-9': 2380,  // engine hours — 280 since last service (due at 500, ok)
+}
+
+export const MOCK_SERVICE_RECORDS: ServiceRecord[] = [
+  {
+    id: 'svc-1', company_id: 'mock-company-1', asset_id: 'asset-2',
+    service_date: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString(),
+    cost: 845.5, vendor: 'Music City Equipment Repair',
+    notes: 'Replaced hydraulic filter, topped fluid.', odometer_or_hours: 1180,
+  },
+  {
+    id: 'svc-2', company_id: 'mock-company-1', asset_id: 'asset-1',
+    service_date: new Date(Date.now() - 70 * 24 * 60 * 60 * 1000).toISOString(),
+    cost: 189.99, vendor: 'Quick Lube Plus',
+    notes: 'Synthetic oil change, rotated tires.', odometer_or_hours: 38000,
+  },
+  {
+    id: 'svc-3', company_id: 'mock-company-1', asset_id: 'asset-9',
+    service_date: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+    cost: 1240.0, vendor: 'Deere Authorized Service',
+    notes: 'Annual inspection, replaced worn hoses.', odometer_or_hours: 2100,
+  },
+]
+
+// ── v2: Utilization ────────────────────────────────────────────────────────────
+export const MOCK_UTILIZATION: AssetUtilization[] = [
+  {
+    asset_id: 'asset-1', asset_name: 'F-350 Truck #1', asset_type: 'vehicle',
+    engine_hours: 168, idle_hours: 31, distance_miles: 2240,
+    job_site_hours: [
+      { geofence_id: 'fence-1', geofence_name: 'Main Site', hours: 96 },
+      { geofence_id: 'fence-2', geofence_name: 'Equipment Yard', hours: 41 },
+    ],
+  },
+  {
+    asset_id: 'asset-2', asset_name: 'CAT 336 Excavator', asset_type: 'equipment',
+    engine_hours: 212, idle_hours: 58, distance_miles: 0,
+    job_site_hours: [{ geofence_id: 'fence-1', geofence_name: 'Main Site', hours: 198 }],
+  },
+  {
+    asset_id: 'asset-9', asset_name: 'JD 310L Backhoe', asset_type: 'equipment',
+    engine_hours: 143, idle_hours: 22, distance_miles: 0,
+    job_site_hours: [{ geofence_id: 'fence-1', geofence_name: 'Main Site', hours: 131 }],
+  },
+  {
+    asset_id: 'asset-6', asset_name: 'Ram 2500 #2', asset_type: 'vehicle',
+    engine_hours: 201, idle_hours: 47, distance_miles: 3110,
+    job_site_hours: [
+      { geofence_id: 'fence-1', geofence_name: 'Main Site', hours: 74 },
+      { geofence_id: 'fence-2', geofence_name: 'Equipment Yard', hours: 88 },
+    ],
+  },
+]
+
+// ── v2: QuickBooks (demo connection) ────────────────────────────────────────────
+export const MOCK_QBO_CONNECTION: QboConnection = {
+  company_id: 'mock-company-1',
+  realm_id: 'demo-realm-4620816365',
+  connected_at: new Date(Date.now() - 12 * 24 * 60 * 60 * 1000).toISOString(),
+  company_name: 'Dillard Construction Group (Sandbox)',
+}
+
+// Equipment billing rates ($/engine-hour) used for usage-invoice generation
+export const MOCK_EQUIPMENT_RATES: Record<string, number> = {
+  'asset-2': 145, // CAT 336 Excavator
+  'asset-9': 95,  // JD 310L Backhoe
+  'asset-1': 45,  // F-350 Truck
+  'asset-6': 45,  // Ram 2500
+}

--- a/lib/qbo.ts
+++ b/lib/qbo.ts
@@ -58,7 +58,7 @@ export function getConnectionStatus() {
   return { connected: false, demo: false, connection: null }
 }
 
-/** Sync TrackFlow assets as QuickBooks fixed-asset items. */
+/** Sync HammerTrack assets as QuickBooks fixed-asset items. */
 export async function syncAssetsAsFixedItems(): Promise<{ synced: number; demo: boolean }> {
   if (!isQboConfigured) {
     // Demo: log what we WOULD send to QBO.

--- a/lib/qbo.ts
+++ b/lib/qbo.ts
@@ -1,0 +1,111 @@
+import type { QboInvoicePreview, AssetUtilization } from './types'
+import { MOCK_QBO_CONNECTION, MOCK_UTILIZATION, MOCK_EQUIPMENT_RATES, MOCK_ASSETS } from './mock-data'
+
+export const isQboConfigured = !!process.env.QBO_CLIENT_ID
+
+const QBO_AUTH_BASE = 'https://appcenter.intuit.com/connect/oauth2'
+const QBO_SCOPES = 'com.intuit.quickbooks.accounting'
+
+/** Build the Intuit OAuth2 authorization URL. */
+export function buildAuthorizeUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: process.env.QBO_CLIENT_ID ?? '',
+    response_type: 'code',
+    scope: QBO_SCOPES,
+    redirect_uri: process.env.QBO_REDIRECT_URI ?? '',
+    state,
+  })
+  return `${QBO_AUTH_BASE}?${params.toString()}`
+}
+
+export interface QboTokenResponse {
+  access_token: string
+  refresh_token: string
+  expires_in: number
+  realmId?: string
+}
+
+/** Exchange an authorization code for tokens (Intuit token endpoint). */
+export async function exchangeCodeForTokens(code: string): Promise<QboTokenResponse> {
+  const tokenUrl = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
+  const basic = Buffer.from(
+    `${process.env.QBO_CLIENT_ID}:${process.env.QBO_CLIENT_SECRET}`
+  ).toString('base64')
+
+  const res = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: process.env.QBO_REDIRECT_URI ?? '',
+    }),
+  })
+  if (!res.ok) throw new Error(`QBO token exchange failed: ${res.status}`)
+  return res.json()
+}
+
+/** Connection status — demo connection when QBO isn't configured. */
+export function getConnectionStatus() {
+  if (!isQboConfigured) {
+    return { connected: true, demo: true, connection: MOCK_QBO_CONNECTION }
+  }
+  // In production, look up qbo_connections for the company.
+  return { connected: false, demo: false, connection: null }
+}
+
+/** Sync TrackFlow assets as QuickBooks fixed-asset items. */
+export async function syncAssetsAsFixedItems(): Promise<{ synced: number; demo: boolean }> {
+  if (!isQboConfigured) {
+    // Demo: log what we WOULD send to QBO.
+    console.log('[QBO demo] would sync fixed assets:', MOCK_ASSETS.map(a => a.name))
+    return { synced: MOCK_ASSETS.length, demo: true }
+  }
+  // Production: POST each asset to /v3/company/{realmId}/item
+  return { synced: 0, demo: false }
+}
+
+/**
+ * Build a billable equipment-usage invoice for a job site (geofence) from
+ * utilization data × per-asset hourly rates.
+ */
+export function buildEquipmentUsageInvoice(
+  jobSiteGeofenceId: string,
+  jobSiteName: string,
+  utilization: AssetUtilization[] = MOCK_UTILIZATION,
+  rates: Record<string, number> = MOCK_EQUIPMENT_RATES
+): QboInvoicePreview {
+  const lines = utilization
+    .map(u => {
+      const site = u.job_site_hours.find(s => s.geofence_id === jobSiteGeofenceId)
+      if (!site || site.hours <= 0) return null
+      const rate = rates[u.asset_id] ?? 0
+      return {
+        description: `${u.asset_name} — equipment usage (${site.hours} hrs @ $${rate}/hr)`,
+        quantity: site.hours,
+        rate,
+        amount: Math.round(site.hours * rate * 100) / 100,
+      }
+    })
+    .filter((l): l is NonNullable<typeof l> => l !== null)
+
+  const total = Math.round(lines.reduce((s, l) => s + l.amount, 0) * 100) / 100
+  return { customer: jobSiteName, job_site: jobSiteName, lines, total }
+}
+
+/** Record a service record as a QuickBooks expense (demo logs the payload). */
+export async function recordServiceExpense(
+  serviceRecordId: string,
+  amount: number,
+  vendor: string
+): Promise<{ ok: boolean; demo: boolean }> {
+  if (!isQboConfigured) {
+    console.log(`[QBO demo] would record expense $${amount} to ${vendor} (svc ${serviceRecordId})`)
+    return { ok: true, demo: true }
+  }
+  return { ok: false, demo: false }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,7 @@
 export type AssetType = 'vehicle' | 'equipment' | 'personnel' | 'tool'
-export type AlertTrigger = 'enter' | 'exit' | 'idle'
+export type AlertTrigger = 'enter' | 'exit' | 'idle' | 'after_hours_movement' | 'left_site'
 export type UserRole = 'admin' | 'viewer'
+export type MaintenanceIntervalType = 'engine_hours' | 'mileage' | 'days'
 
 export interface Company {
   id: string
@@ -8,6 +9,71 @@ export interface Company {
   api_key: string
   plan: string
   created_at: string
+  work_start: string // 'HH:MM' 24h
+  work_end: string
+  work_days: number[] // 0=Sun .. 6=Sat
+}
+
+export interface ToolAssociation {
+  id: string
+  company_id: string
+  tool_asset_id: string
+  gateway_asset_id: string
+  rssi: number | null
+  last_seen: string
+}
+
+export interface MaintenanceSchedule {
+  id: string
+  company_id: string
+  asset_id: string
+  interval_type: MaintenanceIntervalType
+  interval_value: number
+  last_service_value: number
+  last_service_date: string | null
+  description: string
+}
+
+export interface ServiceRecord {
+  id: string
+  company_id: string
+  asset_id: string
+  service_date: string
+  cost: number
+  vendor: string
+  notes: string
+  odometer_or_hours: number | null
+}
+
+export interface AssetUtilization {
+  asset_id: string
+  asset_name: string
+  asset_type: AssetType
+  engine_hours: number
+  idle_hours: number
+  distance_miles: number
+  job_site_hours: { geofence_id: string; geofence_name: string; hours: number }[]
+}
+
+export interface QboConnection {
+  company_id: string
+  realm_id: string
+  connected_at: string
+  company_name: string
+}
+
+export interface QboInvoiceLine {
+  description: string
+  quantity: number
+  rate: number
+  amount: number
+}
+
+export interface QboInvoicePreview {
+  customer: string
+  job_site: string
+  lines: QboInvoiceLine[]
+  total: number
 }
 
 export interface Profile {

--- a/marketing/ad-variants.md
+++ b/marketing/ad-variants.md
@@ -1,0 +1,144 @@
+# HammerTrack — Ad Variants for A/B Testing
+
+All variants drive to **hammertrack.ai/demo** (the funnel landing page).
+Brand voice: blunt, contractor-to-contractor, theft/loss as the hook, price as the closer.
+
+---
+
+## 1. Google Search Ads (high-intent capture)
+
+Target keywords: `tenna alternative`, `equipment gps tracking`, `construction asset tracking`,
+`tool tracking app`, `heavy equipment theft prevention`, `fleet tracking for contractors`.
+
+### Variant A — "Tenna alternative" intent
+- **Headline 1:** Tenna Costs Too Much
+- **Headline 2:** Track Your Fleet for $3/Asset
+- **Headline 3:** No Setup Fees, Cancel Anytime
+- **Description 1:** Trucks, equipment & Bluetooth tools on one map. Half the price of Tenna, $0 setup.
+- **Description 2:** Get a text the second a machine moves after hours. Start a free 30-day pilot.
+
+### Variant B — "theft" intent
+- **Headline 1:** Stop Equipment Theft Tonight
+- **Headline 2:** After-Hours Movement Alerts
+- **Headline 3:** GPS + Bluetooth Tool Tracking
+- **Description 1:** Know the moment a machine leaves the jobsite. Recover gear before it's gone.
+- **Description 2:** Built for construction. QuickBooks built in. Free 30-day pilot, we ship the trackers.
+
+### Variant C — "tool tracking" intent
+- **Headline 1:** Which Truck Is Your Tool In?
+- **Headline 2:** Bluetooth Tool Tracking Built In
+- **Headline 3:** $3–8/Asset · No Contracts
+- **Description 1:** Tag expensive tools, see which truck or machine they're riding in. Live map.
+- **Description 2:** Everything Tenna does for a fraction of the price. Try it free for 30 days.
+
+**Sitelinks:** Pricing · Live Demo · How It Works · vs Tenna
+
+---
+
+## 2. Dealer / Equipment-Rental Co-Marketing (warmest channel)
+
+For equipment dealers, truck dealers, and rental yards to send to their customers.
+Co-branded; revenue-share per activation.
+
+### Email (dealer sends to their customer list)
+**Subject:** Protect the equipment you bought from us — free 30-day trial
+
+> Hi [First Name],
+>
+> You trusted us with [Dealer Name] for your [equipment]. Now protect it.
+>
+> We've partnered with **HammerTrack** — GPS + Bluetooth tracking built for
+> construction crews. Put every machine, truck, and tool on one map, and get
+> an instant text if anything moves after hours or leaves the jobsite.
+>
+> - Half the price of Tenna ($3–8/asset/mo), zero setup fees
+> - Tracks heavy equipment, trucks, AND small tools (Bluetooth)
+> - QuickBooks built in — bill equipment usage to job sites automatically
+>
+> As a [Dealer Name] customer, your first 30 days are free and we ship the
+> trackers to you.
+>
+> **[ Start Your Free Pilot → hammertrack.ai/demo ]**
+
+### Counter-card / flyer (printed, handed out at the parts counter)
+> **JUST BOUGHT A $80K MACHINE?**
+> Don't let it disappear at 2 AM.
+> HammerTrack texts you the second it moves.
+> GPS + Bluetooth tracking · half the price of Tenna · free 30-day pilot.
+> **hammertrack.ai/demo** — ask [Dealer] for your activation code.
+
+---
+
+## 3. Cold Email (outbound to local GCs / fleet owners)
+
+Scrape from the state contractor license registry. Keep it short, one ask.
+
+### Variant A — the 2 AM hook
+**Subject:** your skid steer at 2 AM
+
+> [First Name] — quick one.
+>
+> If a machine left your jobsite at 2 AM tonight, would you know before
+> the crew showed up at 7?
+>
+> HammerTrack puts your whole fleet — trucks, equipment, even Bluetooth-tagged
+> tools — on one map and texts you the second something moves when it
+> shouldn't. Half the price of Tenna, set up in a day, no install crew.
+>
+> Worth a 60-second look? Live demo (no signup): hammertrack.ai/demo
+>
+> — Brian, HammerTrack
+
+### Variant B — the cost hook
+**Subject:** paying Tenna prices?
+
+> [First Name] — are you on Tenna or Samsara for fleet tracking?
+>
+> Same live map, same geofence alerts, plus Bluetooth tool tracking and
+> QuickBooks — for $3–8/asset instead of $15–25, and no $500 setup.
+>
+> 30-day free pilot, we ship the trackers. Live demo here: hammertrack.ai/demo
+>
+> Worth a quick call this week?
+>
+> — Brian, HammerTrack
+
+### Variant C — the tool hook
+**Subject:** which truck is the laser level in?
+
+> [First Name] — how many hours a week does your crew lose hunting for tools
+> that walked off to the wrong truck?
+>
+> HammerTrack tags your expensive tools with a $20 Bluetooth beacon and shows
+> you exactly which truck or machine each one is riding in. Plus full GPS on
+> trucks and equipment.
+>
+> 60-second demo, no signup: hammertrack.ai/demo
+>
+> — Brian, HammerTrack
+
+---
+
+## 4. Facebook / Instagram (already built — see lead-funnel-infographic.html)
+
+**Primary text:** Your $80K excavator just left the jobsite at 2 AM. Did you know?
+HammerTrack puts every truck, machine, and power tool on one map — and texts
+you the second something moves when it shouldn't. Half the price of Tenna.
+Setup in a day, no install crew.
+**Headline:** Start a Free 30-Day Pilot
+**CTA button:** Learn More → hammertrack.ai/demo
+**Audience:** Construction owners/fleet managers, 50mi radius, interests: heavy
+equipment, construction management, QuickBooks.
+
+---
+
+## A/B testing plan
+
+| Test | Channel | What to measure | Winner signal |
+|---|---|---|---|
+| Hook: theft vs cost vs tools | All | Click-through rate | Highest CTR hook becomes primary |
+| Subject lines (cold email) | Email | Open rate | >40% open = keep |
+| CTA: "Free Pilot" vs "Live Demo" | FB/Google | Landing → register | Higher demo→trial conversion |
+| Dealer co-brand vs solo | Email | Activation rate | Dealer warm leads should 2–3x solo |
+
+Run each hook for ~$200 spend or 500 sends before calling a winner.

--- a/marketing/ad-variants.md
+++ b/marketing/ad-variants.md
@@ -1,6 +1,6 @@
 # HammerTrack — Ad Variants for A/B Testing
 
-All variants drive to **hammertrack.ai/demo** (the funnel landing page).
+All variants drive to **hammertrackai.com/demo** (the funnel landing page).
 Brand voice: blunt, contractor-to-contractor, theft/loss as the hook, price as the closer.
 
 ---
@@ -58,14 +58,14 @@ Co-branded; revenue-share per activation.
 > As a [Dealer Name] customer, your first 30 days are free and we ship the
 > trackers to you.
 >
-> **[ Start Your Free Pilot → hammertrack.ai/demo ]**
+> **[ Start Your Free Pilot → hammertrackai.com/demo ]**
 
 ### Counter-card / flyer (printed, handed out at the parts counter)
 > **JUST BOUGHT A $80K MACHINE?**
 > Don't let it disappear at 2 AM.
 > HammerTrack texts you the second it moves.
 > GPS + Bluetooth tracking · half the price of Tenna · free 30-day pilot.
-> **hammertrack.ai/demo** — ask [Dealer] for your activation code.
+> **hammertrackai.com/demo** — ask [Dealer] for your activation code.
 
 ---
 
@@ -85,7 +85,7 @@ Scrape from the state contractor license registry. Keep it short, one ask.
 > tools — on one map and texts you the second something moves when it
 > shouldn't. Half the price of Tenna, set up in a day, no install crew.
 >
-> Worth a 60-second look? Live demo (no signup): hammertrack.ai/demo
+> Worth a 60-second look? Live demo (no signup): hammertrackai.com/demo
 >
 > — Brian, HammerTrack
 
@@ -97,7 +97,7 @@ Scrape from the state contractor license registry. Keep it short, one ask.
 > Same live map, same geofence alerts, plus Bluetooth tool tracking and
 > QuickBooks — for $3–8/asset instead of $15–25, and no $500 setup.
 >
-> 30-day free pilot, we ship the trackers. Live demo here: hammertrack.ai/demo
+> 30-day free pilot, we ship the trackers. Live demo here: hammertrackai.com/demo
 >
 > Worth a quick call this week?
 >
@@ -113,7 +113,7 @@ Scrape from the state contractor license registry. Keep it short, one ask.
 > you exactly which truck or machine each one is riding in. Plus full GPS on
 > trucks and equipment.
 >
-> 60-second demo, no signup: hammertrack.ai/demo
+> 60-second demo, no signup: hammertrackai.com/demo
 >
 > — Brian, HammerTrack
 
@@ -126,7 +126,7 @@ HammerTrack puts every truck, machine, and power tool on one map — and texts
 you the second something moves when it shouldn't. Half the price of Tenna.
 Setup in a day, no install crew.
 **Headline:** Start a Free 30-Day Pilot
-**CTA button:** Learn More → hammertrack.ai/demo
+**CTA button:** Learn More → hammertrackai.com/demo
 **Audience:** Construction owners/fleet managers, 50mi radius, interests: heavy
 equipment, construction management, QuickBooks.
 

--- a/marketing/lead-funnel-infographic.html
+++ b/marketing/lead-funnel-infographic.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>TrackFlow — Lead Funnel & Go-to-Market</title>
+<title>HammerTrack — Lead Funnel & Go-to-Market</title>
 <style>
   :root{
     --ink:#0f172a; --slate:#475569; --mute:#94a3b8;
@@ -77,7 +77,7 @@
 <div class="wrap">
 
   <div class="head">
-    <div class="logo"><span class="dot"></span> TrackFlow</div>
+    <div class="logo"><span class="dot"></span> HammerTrack</div>
     <div class="sub">Asset tracking that pays for itself before the first stolen tool.</div>
     <div class="tag">Go-to-Market &amp; Lead Funnel · Built for regional construction fleets</div>
   </div>
@@ -161,16 +161,16 @@
     </div>
     <div class="body">
       <div class="headline">Your $80K excavator just left the jobsite at 2 AM. Did you know?</div>
-      <div class="copy">TrackFlow puts every truck, machine, and power tool on one map — and texts you the second something moves when it shouldn't. Half the price of Tenna. Setup in a day, no install crew.</div>
+      <div class="copy">HammerTrack puts every truck, machine, and power tool on one map — and texts you the second something moves when it shouldn't. Half the price of Tenna. Setup in a day, no install crew.</div>
       <div class="cta">
         <span class="btn">Start Free 30-Day Pilot →</span>
       </div>
-      <div class="url" style="margin-top:10px">trackflow.app/pricing</div>
+      <div class="url" style="margin-top:10px">hammertrack.ai/pricing</div>
     </div>
   </div>
   <div class="adnote">Primary text + creative for Meta Ads Manager · Audience: construction owners/fleet managers, 50mi radius</div>
 
-  <div class="foot">TrackFlow · Competitive go-to-market plan · Funnel numbers are planning targets, not guarantees</div>
+  <div class="foot">HammerTrack · Competitive go-to-market plan · Funnel numbers are planning targets, not guarantees</div>
 </div>
 </body>
 </html>

--- a/marketing/lead-funnel-infographic.html
+++ b/marketing/lead-funnel-infographic.html
@@ -165,7 +165,7 @@
       <div class="cta">
         <span class="btn">Start Free 30-Day Pilot →</span>
       </div>
-      <div class="url" style="margin-top:10px">hammertrack.ai/pricing</div>
+      <div class="url" style="margin-top:10px">hammertrackai.com/pricing</div>
     </div>
   </div>
   <div class="adnote">Primary text + creative for Meta Ads Manager · Audience: construction owners/fleet managers, 50mi radius</div>

--- a/marketing/lead-funnel-infographic.html
+++ b/marketing/lead-funnel-infographic.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>TrackFlow — Lead Funnel & Go-to-Market</title>
+<style>
+  :root{
+    --ink:#0f172a; --slate:#475569; --mute:#94a3b8;
+    --brand:#f97316; --brand2:#ea580c; --teal:#0d9488; --line:#e2e8f0;
+    --bg:#f8fafc; --card:#ffffff;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+       background:var(--bg);color:var(--ink);padding:40px 20px;line-height:1.5}
+  .wrap{max-width:920px;margin:0 auto}
+  .head{text-align:center;margin-bottom:36px}
+  .logo{display:inline-flex;align-items:center;gap:10px;font-weight:800;font-size:30px;letter-spacing:-.5px}
+  .dot{width:16px;height:16px;border-radius:50%;background:var(--brand);box-shadow:0 0 0 5px rgba(249,115,22,.18)}
+  .sub{color:var(--slate);font-size:15px;margin-top:8px}
+  .tag{display:inline-block;margin-top:14px;background:#fff7ed;color:#c2410c;border:1px solid #fed7aa;
+       padding:6px 14px;border-radius:999px;font-size:13px;font-weight:700}
+
+  h2{font-size:13px;letter-spacing:1.5px;text-transform:uppercase;color:var(--mute);
+     margin:40px 0 16px;text-align:center}
+
+  /* FUNNEL */
+  .funnel{display:flex;flex-direction:column;align-items:center;gap:8px}
+  .stage{position:relative;color:#fff;border-radius:12px;padding:18px 24px;width:100%;
+         display:flex;align-items:center;justify-content:space-between;box-shadow:0 6px 18px rgba(2,6,23,.08)}
+  .s1{max-width:760px;background:linear-gradient(135deg,#fb923c,#f97316)}
+  .s2{max-width:620px;background:linear-gradient(135deg,#f97316,#ea580c)}
+  .s3{max-width:480px;background:linear-gradient(135deg,#ea580c,#c2410c)}
+  .s4{max-width:360px;background:linear-gradient(135deg,#0d9488,#0f766e)}
+  .s5{max-width:260px;background:linear-gradient(135deg,#0f766e,#115e59)}
+  .stage .l{font-weight:800;font-size:16px}
+  .stage .d{font-size:12.5px;opacity:.92;margin-top:2px;font-weight:500}
+  .stage .n{font-weight:800;font-size:19px;white-space:nowrap;margin-left:18px}
+  .arrow{color:var(--mute);font-size:18px;line-height:1}
+
+  .convo{display:flex;justify-content:center;gap:30px;flex-wrap:wrap;margin-top:22px;
+         color:var(--slate);font-size:13px}
+  .convo b{color:var(--ink)}
+
+  /* CHANNELS */
+  .grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px}
+  .card h3{font-size:15px;margin-bottom:6px;display:flex;align-items:center;gap:8px}
+  .card p{font-size:13px;color:var(--slate)}
+  .pill{font-size:11px;font-weight:700;padding:3px 9px;border-radius:999px;margin-left:auto}
+  .hot{background:#fef2f2;color:#dc2626}
+  .warm{background:#fff7ed;color:#c2410c}
+  .cool{background:#eff6ff;color:#2563eb}
+
+  /* AD */
+  .ad{background:#1e293b;border-radius:16px;overflow:hidden;box-shadow:0 12px 30px rgba(2,6,23,.25);max-width:420px;margin:0 auto}
+  .ad .img{height:190px;background:linear-gradient(135deg,#0f172a,#1e3a5f);position:relative;overflow:hidden}
+  .ad .map-dots{position:absolute;inset:0}
+  .ad .pin{position:absolute;width:14px;height:14px;border-radius:50% 50% 50% 0;transform:rotate(-45deg);
+           box-shadow:0 2px 6px rgba(0,0,0,.4)}
+  .ad .pin.o{background:#f97316}.ad .pin.t{background:#0d9488}.ad .pin.r{background:#ef4444}
+  .ad .badge{position:absolute;top:14px;left:14px;background:rgba(15,23,42,.7);color:#fff;
+             padding:6px 12px;border-radius:8px;font-size:12px;font-weight:700;backdrop-filter:blur(4px)}
+  .ad .body{padding:20px;background:#fff}
+  .ad .headline{font-size:20px;font-weight:800;color:var(--ink);line-height:1.25}
+  .ad .copy{font-size:14px;color:var(--slate);margin-top:8px}
+  .ad .cta{margin-top:16px;display:flex;align-items:center;justify-content:space-between;gap:12px}
+  .ad .btn{background:var(--brand);color:#fff;font-weight:800;font-size:14px;padding:11px 18px;
+           border-radius:10px;border:none;flex:1;text-align:center}
+  .ad .url{font-size:12px;color:var(--mute);font-weight:600}
+  .adnote{text-align:center;color:var(--mute);font-size:12px;margin-top:12px}
+
+  .foot{text-align:center;color:var(--mute);font-size:12px;margin-top:44px;border-top:1px solid var(--line);padding-top:18px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="head">
+    <div class="logo"><span class="dot"></span> TrackFlow</div>
+    <div class="sub">Asset tracking that pays for itself before the first stolen tool.</div>
+    <div class="tag">Go-to-Market &amp; Lead Funnel · Built for regional construction fleets</div>
+  </div>
+
+  <h2>The Lead Funnel</h2>
+  <div class="funnel">
+    <div class="stage s1">
+      <div><div class="l">AWARENESS</div><div class="d">Facebook/IG geo-ads · Trade FB groups · Equipment-dealer referrals</div></div>
+      <div class="n">10,000</div>
+    </div>
+    <div class="arrow">▼</div>
+    <div class="stage s2">
+      <div><div class="l">CLICK → LANDING</div><div class="d">"See your whole fleet on one map" · /pricing page</div></div>
+      <div class="n">600</div>
+    </div>
+    <div class="arrow">▼</div>
+    <div class="stage s3">
+      <div><div class="l">LEAD (Demo request)</div><div class="d">Live demo-mode app · no signup wall</div></div>
+      <div class="n">120</div>
+    </div>
+    <div class="arrow">▼</div>
+    <div class="stage s4">
+      <div><div class="l">TRIAL / PILOT</div><div class="d">5 trackers, 30 days, we ship hardware</div></div>
+      <div class="n">35</div>
+    </div>
+    <div class="arrow">▼</div>
+    <div class="stage s5">
+      <div><div class="l">PAID</div><div class="d">$3–8 / asset / mo</div></div>
+      <div class="n">12</div>
+    </div>
+  </div>
+
+  <div class="convo">
+    <span><b>6%</b> click-through</span>
+    <span><b>20%</b> lead capture</span>
+    <span><b>29%</b> demo → pilot</span>
+    <span><b>34%</b> pilot → paid</span>
+    <span><b>~$1.2%</b> ad → customer</span>
+  </div>
+
+  <h2>Channel Priority</h2>
+  <div class="grid">
+    <div class="card">
+      <h3>📍 Local FB/IG Ads <span class="pill hot">HOT</span></h3>
+      <p>Geo-target 50mi around your metro. Target job titles: owner, fleet manager, GC. Cheapest CPM, your buyers live here.</p>
+    </div>
+    <div class="card">
+      <h3>🤝 Dealer Referrals <span class="pill hot">HOT</span></h3>
+      <p>Equipment & truck dealers refer buyers. Revenue-share per activation. Warmest leads, highest close rate.</p>
+    </div>
+    <div class="card">
+      <h3>🔍 Google Search <span class="pill warm">WARM</span></h3>
+      <p>"Tenna alternative", "equipment GPS tracking", "tool tracking app". High intent, higher CPC.</p>
+    </div>
+    <div class="card">
+      <h3>👥 Trade FB Groups <span class="pill warm">WARM</span></h3>
+      <p>Contractor & GC groups. Show, don't sell — post the theft-alert story. Free reach.</p>
+    </div>
+    <div class="card">
+      <h3>📱 Trade Shows <span class="pill cool">COOL</span></h3>
+      <p>Regional construction expos. Live demo on a tablet. High cost, great for credibility.</p>
+    </div>
+    <div class="card">
+      <h3>📧 Cold Email <span class="pill cool">COOL</span></h3>
+      <p>Scrape local GC license registry. "Spot-check your fleet in 60 sec" demo link.</p>
+    </div>
+  </div>
+
+  <h2>Example Ad — Facebook / Instagram</h2>
+  <div class="ad">
+    <div class="img">
+      <div class="map-dots">
+        <div class="pin o" style="top:40px;left:60px"></div>
+        <div class="pin o" style="top:90px;left:140px"></div>
+        <div class="pin t" style="top:60px;left:240px"></div>
+        <div class="pin t" style="top:120px;left:300px"></div>
+        <div class="pin r" style="top:30px;left:340px"></div>
+        <div class="pin o" style="top:140px;left:90px"></div>
+      </div>
+      <div class="badge">🔴 After-hours movement — Skid Steer #3</div>
+    </div>
+    <div class="body">
+      <div class="headline">Your $80K excavator just left the jobsite at 2 AM. Did you know?</div>
+      <div class="copy">TrackFlow puts every truck, machine, and power tool on one map — and texts you the second something moves when it shouldn't. Half the price of Tenna. Setup in a day, no install crew.</div>
+      <div class="cta">
+        <span class="btn">Start Free 30-Day Pilot →</span>
+      </div>
+      <div class="url" style="margin-top:10px">trackflow.app/pricing</div>
+    </div>
+  </div>
+  <div class="adnote">Primary text + creative for Meta Ads Manager · Audience: construction owners/fleet managers, 50mi radius</div>
+
+  <div class="foot">TrackFlow · Competitive go-to-market plan · Funnel numbers are planning targets, not guarantees</div>
+</div>
+</body>
+</html>

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,7 +30,7 @@ export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
   const isPublic = pathname.startsWith('/login') || pathname.startsWith('/register') ||
-    pathname.startsWith('/pricing') || pathname.startsWith('/api')
+    pathname.startsWith('/pricing') || pathname.startsWith('/demo') || pathname.startsWith('/api')
   if (!user && !isPublic) {
     return NextResponse.redirect(new URL('/login', request.url))
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,7 +29,8 @@ export async function middleware(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   const pathname = request.nextUrl.pathname
 
-  const isPublic = pathname.startsWith('/login') || pathname.startsWith('/register') || pathname.startsWith('/api')
+  const isPublic = pathname.startsWith('/login') || pathname.startsWith('/register') ||
+    pathname.startsWith('/pricing') || pathname.startsWith('/api')
   if (!user && !isPublic) {
     return NextResponse.redirect(new URL('/login', request.url))
   }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "TrackFlow",
-  "short_name": "TrackFlow",
+  "name": "HammerTrack",
+  "short_name": "HammerTrack",
   "description": "Real-time asset tracking for construction companies",
   "start_url": "/map",
   "display": "standalone",

--- a/supabase/migrations/002_v2.sql
+++ b/supabase/migrations/002_v2.sql
@@ -1,4 +1,4 @@
--- TrackFlow v2: Bluetooth tools, theft alerts, maintenance, QuickBooks
+-- HammerTrack v2: Bluetooth tools, theft alerts, maintenance, QuickBooks
 -- Run after 001_initial.sql
 
 -- ── Work hours on companies (for after-hours theft detection) ──────────────────

--- a/supabase/migrations/002_v2.sql
+++ b/supabase/migrations/002_v2.sql
@@ -1,0 +1,80 @@
+-- TrackFlow v2: Bluetooth tools, theft alerts, maintenance, QuickBooks
+-- Run after 001_initial.sql
+
+-- ── Work hours on companies (for after-hours theft detection) ──────────────────
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS work_start TEXT NOT NULL DEFAULT '07:00';
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS work_end   TEXT NOT NULL DEFAULT '17:00';
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS work_days  INTEGER[] NOT NULL DEFAULT '{1,2,3,4,5,6}';
+
+-- ── New alert trigger types ────────────────────────────────────────────────────
+-- alert_rules.trigger was CHECK (enter|exit|idle). Widen it.
+ALTER TABLE alert_rules DROP CONSTRAINT IF EXISTS alert_rules_trigger_check;
+ALTER TABLE alert_rules ADD CONSTRAINT alert_rules_trigger_check
+  CHECK (trigger IN ('enter', 'exit', 'idle', 'after_hours_movement', 'left_site'));
+
+-- ── Bluetooth tool associations (which gateway currently "holds" a tool) ────────
+CREATE TABLE IF NOT EXISTS tool_associations (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id      UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  tool_asset_id   UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  gateway_asset_id UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  rssi            INTEGER,
+  last_seen       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tool_asset_id)
+);
+CREATE INDEX IF NOT EXISTS tool_assoc_company_idx ON tool_associations(company_id);
+CREATE INDEX IF NOT EXISTS tool_assoc_gateway_idx ON tool_associations(gateway_asset_id);
+
+-- ── Maintenance ─────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS maintenance_schedules (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id         UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  asset_id           UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  interval_type      TEXT NOT NULL CHECK (interval_type IN ('engine_hours', 'mileage', 'days')),
+  interval_value     NUMERIC NOT NULL,
+  last_service_value NUMERIC NOT NULL DEFAULT 0,
+  last_service_date  TIMESTAMPTZ,
+  description        TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS maint_sched_company_idx ON maintenance_schedules(company_id);
+
+CREATE TABLE IF NOT EXISTS service_records (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id        UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+  asset_id          UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+  service_date      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  cost              NUMERIC NOT NULL DEFAULT 0,
+  vendor            TEXT NOT NULL DEFAULT '',
+  notes             TEXT NOT NULL DEFAULT '',
+  odometer_or_hours NUMERIC
+);
+CREATE INDEX IF NOT EXISTS svc_records_company_idx ON service_records(company_id, service_date DESC);
+
+-- ── QuickBooks Online connection (tokens stored server-side only) ───────────────
+CREATE TABLE IF NOT EXISTS qbo_connections (
+  company_id    UUID PRIMARY KEY REFERENCES companies(id) ON DELETE CASCADE,
+  realm_id      TEXT NOT NULL,
+  access_token  TEXT NOT NULL,
+  refresh_token TEXT NOT NULL,
+  expires_at    TIMESTAMPTZ NOT NULL,
+  company_name  TEXT,
+  connected_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── RLS for new tenant tables ────────────────────────────────────────────────────
+ALTER TABLE tool_associations    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE maintenance_schedules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_records       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE qbo_connections       ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "company tool associations" ON tool_associations
+  FOR ALL USING (company_id = current_company_id());
+CREATE POLICY "company maintenance schedules" ON maintenance_schedules
+  FOR ALL USING (company_id = current_company_id());
+CREATE POLICY "company service records" ON service_records
+  FOR ALL USING (company_id = current_company_id());
+CREATE POLICY "company qbo connection" ON qbo_connections
+  FOR ALL USING (company_id = current_company_id());
+
+-- Realtime for tool associations (live "which truck" updates)
+ALTER PUBLICATION supabase_realtime ADD TABLE tool_associations;


### PR DESCRIPTION
Remaining changes since v2 merge:

- `CLAUDE.md` — full project handoff doc for session continuity (hardware stack, DNS, pending steps, GTM, architecture notes)
- Domain references updated: `hammertrack.ai` → `hammertrackai.com` throughout
- Ad variants file (`marketing/ad-variants.md`) — Google Search, dealer co-marketing, cold email
- Lead funnel infographic updated with correct domain

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD4hHZiWbcu7CPp5fuSqYx)_